### PR TITLE
Fix invalid resources cpu definition

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - email: "nais@nav.no"
     name: "nais"
 type: application
-version: 1.4.2
+version: 1.4.3

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -5,7 +5,7 @@ backend:
     tag: main
   resources:
     requests:
-      Cpu: 100m
+      cpu: 100m
       memory: 256Mi
   logLevel: info
   logFormat: json


### PR DESCRIPTION
```
Error: release bifrost failed, and has been uninstalled due to atomic being set: Deployment.apps "bifrost-backend" is invalid: [spec.template.spec.containers[0].resources.requests[Cpu]: Invalid value: "Cpu": must be a standard resource type or fully qualified, spec.template.spec.containers[0].resources.requests[Cpu]: Invalid value: "Cpu": must be a standard resource for containers]
```