### PR TITLE
Allow all paths for Unleash API ingress

### DIFF
--- a/pkg/unleash/resources.go
+++ b/pkg/unleash/resources.go
@@ -117,7 +117,8 @@ func NewUnleashSpec(
 			ApiIngress: unleashv1.IngressConfig{
 				Enabled: true,
 				Host:    fmt.Sprintf("%s-%s", teamName, c.Unleash.InstanceAPIIngressHost),
-				Path:    "/api",
+				// Allow access to /health endpoint, change to /api when https://github.com/nais/unleasherator/issues/100 is resolved
+				Path:    "/",
 				Class:   c.Unleash.InstanceAPIIngressClass,
 			},
 			NetworkPolicy: unleashv1.NetworkPolicyConfig{

--- a/pkg/unleash/resources_test.go
+++ b/pkg/unleash/resources_test.go
@@ -133,7 +133,7 @@ func TestNewUnleashSpec(t *testing.T) {
 			ApiIngress: unleashv1.IngressConfig{
 				Enabled: true,
 				Host:    "my-team-unleash-api.example.com",
-				Path:    "/api",
+				Path:    "/",
 				Class:   "unleash-api-ingress-class",
 			},
 			NetworkPolicy: unleashv1.NetworkPolicyConfig{


### PR DESCRIPTION
Allow all paths to Unleash API ingress in order to allow Unleasherator heath
checks to succeed. This is tracked in https://github.com/nais/unleasherator/issues/100
