### PR TITLE
Fix Helm secret template

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - email: "nais@nav.no"
     name: "nais"
 type: application
-version: 1.6.0
+version: 1.6.1

--- a/charts/bifrost/templates/backend-secret.yaml
+++ b/charts/bifrost/templates/backend-secret.yaml
@@ -4,5 +4,6 @@ metadata:
   name: {{ include "bifrost.fullname" . }}-backend
   labels:
     {{- include "bifrost.labels" . | nindent 4 }}
-data:
+type: Opaque
+stringData:
   {{ .Values.backend.teams.apiTokenSecretKey }}: {{ .Values.backend.teams.apiToken | required ".teams.apiToken can not be empty" }}

--- a/charts/bifrost/templates/unleash-secret.yaml
+++ b/charts/bifrost/templates/unleash-secret.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: {{ .Values.backend.unleash.instanceNamespace }}
   labels:
     {{- include "bifrost.labels" . | nindent 4 }}
-data:
+type: Opaque
+stringData:
   {{ .Values.backend.unleash.teamsApiTokenSecretKey }}: {{ .Values.backend.unleash.teamsApiToken | required "unleash.teamsApiToken can not be empty" }}


### PR DESCRIPTION
```
Error: UPGRADE FAILED: release bifrost failed, and has been rolled back due to atomic being set: failed to create resource: Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 4
```
