### PR TITLE
Add Dependabot grouped versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - k8s.io/api
+          - k8s.io/apimachinery
+          - k8s.io/client-go
+      kubebuilder-dependencies:
+        patterns:
+          - sigs.k8s.io/controller-runtime
+          - sigs.k8s.io/controller-tools
     ignore:
       # These pacakges are dependent on the Kubernetes version we are targeting
       - dependency-name: "k8s.io/api"


### PR DESCRIPTION
Ref. https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
