### PR TITLE
Allow traffic to GitHub API (take II)

### DIFF
--- a/charts/bifrost/templates/backend-netpol.yaml
+++ b/charts/bifrost/templates/backend-netpol.yaml
@@ -23,6 +23,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
+  {{- end }}
   # GitHub API
   - to:
     - ipBlock:
@@ -32,8 +33,6 @@ spec:
     ports:
     - port: 443
       protocol: TCP
-   u
-  {{- end }}
   podSelector:
     matchLabels:
       {{- include "bifrost.selectorLabels" . | nindent 6 }}

--- a/charts/bifrost/templates/backend-netpol.yaml
+++ b/charts/bifrost/templates/backend-netpol.yaml
@@ -19,10 +19,20 @@ spec:
         matchLabels:
           k8s-app: node-local-dns
     ports:
-      - port: 53
-        protocol: UDP
-      - port: 53
-        protocol: TCP
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  # GitHub API
+  - to:
+    - ipBlock:
+        cidr: 140.82.121.5/32
+    - ipBlock:
+        cidr: 140.82.121.6/32
+    ports:
+    - port: 443
+      protocol: TCP
+   u
   {{- end }}
   podSelector:
     matchLabels:


### PR DESCRIPTION
FQDNNetworkPolicies are a little bity flaky when it comes to dynamic adddresses.
This is only a hack for the two common addresses at this time.
