### PR TITLE
Disable invalid Prometheus ServiceMonitor

### DIFF
--- a/charts/bifrost/templates/backend-servicemonitor.yaml
+++ b/charts/bifrost/templates/backend-servicemonitor.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -15,3 +16,4 @@ spec:
   selector:
     matchLabels:
       {{- include "bifrost.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -65,3 +65,9 @@ networkPolicy:
   allowDNS: true
   # apiServerCIDR is the CIDR of the Kubernetes API server.
   # apiServerCIDR: 1.2.3.4/32
+
+metrics:
+  enabled: false
+
+alerts:
+  enabled: true


### PR DESCRIPTION
We currently do not have any metrics from Bifrost
