### PR TITLE
ci: inline fasit-deploy job on v4.0.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,5 +25,22 @@ jobs:
       mise-tasks: '["tidy-check", "fmt-check", "generate-check", "lint", "vet", "check", "test-race"]'
       builds-docker: true
       builds-chart: true
-      deploys-to-fasit: true
       creates-git-tag: true
+
+  deploy:
+    name: Deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-and-deploy
+    runs-on: fasit-deploy
+    permissions:
+      id-token: write
+    steps:
+      - uses: nais/fasit-deploy@58a70a338b16dc646373c91724fc7e7522d085a4 # ratchet:nais/fasit-deploy@v4.0.1
+        with:
+          chart: oci://europe-north1-docker.pkg.dev/nais-io/nais/charts/${{ needs.build-and-deploy.outputs.name }}
+          version: ${{ needs.build-and-deploy.outputs.version }}
+          targets: |
+            [
+              { "target": { "kind": "management", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "management" } }
+            ]


### PR DESCRIPTION
Drop `deploys-to-fasit: true` from the `nais/actions/.../mise-build-deploy-fasit.yaml` reusable workflow call (which still uses `nais/fasit-deploy@v2`) and add a local `deploy` job that uses `nais/fasit-deploy@v4.0.1` with an explicit `targets` list.

`Feature.yaml` declares `environmentKinds: [management]`. Targets: ci-nais wait, then broad management fanout.

Reuses outputs (`name`, `version`) from the reusable workflow's `meta` job. Chart repo `nais-io/nais/charts` matches the reusable workflow default.