### PR TITLE
Remove Teams API token secret handling from chart and config

### DIFF
--- a/charts/bifrost/Feature.yaml
+++ b/charts/bifrost/Feature.yaml
@@ -18,13 +18,7 @@ values:
   backend.image.tag:
     config:
       type: string
-  backend.teams.apiToken:
-    displayName: Teams API key for Bifrost backend
-    computed:
-      template: '"{{ .Management.bifrost_teams_api_key }}"'
-  backend.teams.apiUrl:
-    computed:
-      template: '"https://{{ subdomain . "console" }}/graphql"'
+
   backend.unleash.apiIngressClass:
     displayName: Api Ingress Class
     computed:
@@ -97,6 +91,7 @@ values:
     displayName: Unleash sql instance region
     computed:
       template: '"{{ .Management.bifrost_unleash_sql_instance_region }}"'
+
   backend.unleash.teamsApiToken:
     displayName: Teams API key for Unleash instances
     computed:

--- a/charts/bifrost/templates/backend-deployment.yaml
+++ b/charts/bifrost/templates/backend-deployment.yaml
@@ -52,14 +52,6 @@ spec:
             # Google
             - name: BIFROST_GOOGLE_PROJECT_ID
               value: {{ .Values.backend.google.projectId | quote }}
-            # Teams
-            - name: BIFROST_TEAMS_API_URL
-              value: {{ .Values.backend.teams.apiUrl | quote }}
-            - name: BIFROST_TEAMS_API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "bifrost.fullname" . }}-backend
-                  key: {{ .Values.backend.teams.apiTokenSecretKey }}
             # Unleash
             - name: BIFROST_UNLEASH_SQL_INSTANCE_ID
               value: {{ .Values.backend.unleash.sqlInstanceId | required ".unleash.sqlInstanceId is required" | quote }}

--- a/charts/bifrost/templates/backend-secret.yaml
+++ b/charts/bifrost/templates/backend-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "bifrost.fullname" . }}-backend
-  labels:
-    {{- include "bifrost.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  {{ .Values.backend.teams.apiTokenSecretKey }}: {{ .Values.backend.teams.apiToken | required ".teams.apiToken can not be empty" }}

--- a/charts/bifrost/values-local.yaml
+++ b/charts/bifrost/values-local.yaml
@@ -35,9 +35,6 @@ backend:
     serviceAccountEmail: foo@bar
     iapBackendServiceId: 123
 
-  teams:
-    apiToken: foo
-
 ingress:
   host: foo.bar
 

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -70,11 +70,6 @@ backend:
     # projectId:  # mapped in fasit
     # serviceAccountEmail:  # mapped in fasit
 
-  teams:
-    apiUrl: https://console.nav.cloud.nais.io/graphql
-    # apiToken:  # mapped in fasit
-    apiTokenSecretKey: token
-
 nameOverride: ""
 fullnameOverride: ""
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,11 +62,6 @@ type GoogleConfig struct {
 	ProjectID string `env:"BIFROST_GOOGLE_PROJECT_ID,required"`
 }
 
-type TeamsConfig struct {
-	TeamsApiURL   string `env:"BIFROST_TEAMS_API_URL,required"`
-	TeamsApiToken string `env:"BIFROST_TEAMS_API_TOKEN,required"`
-}
-
 type UnleashConfig struct {
 	InstanceNamespace           string `env:"BIFROST_UNLEASH_INSTANCE_NAMESPACE,required"`
 	InstanceServiceaccount      string `env:"BIFROST_UNLEASH_INSTANCE_SERVICEACCOUNT,required"`
@@ -147,7 +142,6 @@ type Config struct {
 	Meta                MetaConfig
 	Server              ServerConfig
 	Google              GoogleConfig
-	Teams               TeamsConfig
 	Unleash             UnleashConfig
 	DebugMode           bool
 	CloudConnectorProxy string `env:"BIFROST_CLOUD_CONNECTOR_PROXY_IMAGE,default=gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0"`


### PR DESCRIPTION
Vi gjør litt jobb for å erstatte static service accounts laget via terraform. Dette lar oss fjerne én siden den ikke er i bruk. 
Vi må på sikt også se på hvordan vi løser nais/unleash