### PR TITLE
Harden provisioning (rollback/idempotency) and add pre-shared-key auth

### DIFF
--- a/charts/bifrost/Feature.yaml
+++ b/charts/bifrost/Feature.yaml
@@ -18,6 +18,16 @@ values:
     config:
       type: string
 
+  # API authentication (pre-shared key shared with nais-api).
+  backend.auth.apiKeys:
+    displayName: Bifrost API pre-shared key(s)
+    computed:
+      template: '"{{ .Management.bifrost_api_key }}"'
+  backend.auth.enforced:
+    displayName: Enforce API authentication (reject unauthenticated requests)
+    config:
+      type: bool
+
   backend.unleash.apiIngressClass:
     displayName: Api Ingress Class
     computed:

--- a/charts/bifrost/templates/backend-api-key-secret.yaml
+++ b/charts/bifrost/templates/backend-api-key-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.backend.auth.apiKeys }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.backend.auth.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.backend.auth.secretKey }}: {{ .Values.backend.auth.apiKeys | quote }}
+{{- end }}

--- a/charts/bifrost/templates/backend-deployment.yaml
+++ b/charts/bifrost/templates/backend-deployment.yaml
@@ -103,6 +103,17 @@ spec:
             - name: BIFROST_UNLEASH_CHANNEL_MIGRATION_DELAY
               value: {{ .Values.backend.unleash.channelMigration.delay | quote }}
             {{- end }}
+
+            # API authentication (pre-shared key from nais-api). See docs/RECONCILER_IMPROVEMENT_PLAN.md.
+            - name: BIFROST_AUTH_ENFORCED
+              value: {{ .Values.backend.auth.enforced | quote }}
+            {{- if .Values.backend.auth.apiKeys }}
+            - name: BIFROST_API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.auth.secretName }}
+                  key: {{ .Values.backend.auth.secretKey }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -11,6 +11,20 @@ backend:
   logLevel: info
   logFormat: json
 
+  # API authentication. Bifrost is called only by nais-api; auth is a pre-shared
+  # key held in fasit and injected into both. Ships in accept-then-enforce mode.
+  auth:
+    # Comma-separated pre-shared keys (multiple allow zero-downtime rotation).
+    # Mapped from fasit; empty means authentication is effectively disabled.
+    apiKeys: ""  # mapped in fasit
+    # When true, requests without a valid key are rejected with 401. Keep false
+    # until nais-api is confirmed sending the key, then flip to true.
+    enforced: false
+    # Name/key of the Secret (created by this chart when apiKeys is set) that
+    # holds the keys and is mounted into bifrost's env as BIFROST_API_KEYS.
+    secretName: bifrost-api-key
+    secretKey: api-keys
+
   unleash:
     # Kubernetes namespace to create unleash instances in
     # instanceNamespace:  # mapped in fasit

--- a/docs/RECONCILER_IMPROVEMENT_PLAN.md
+++ b/docs/RECONCILER_IMPROVEMENT_PLAN.md
@@ -289,6 +289,41 @@ Each phase is independently shippable and leaves the system better than before.
   (`BIFROST_RECONCILER_ENABLED`, default off); enable in a non-prod tenant first; watch drift/apply
   metrics; then enable in prod with `replicas: 1` until leader election lands, then scale.
 
+## 6a. Progressive delivery — dark-launch every breaking change
+
+Every behaviour-changing rollout in bifrost follows the same SRE pattern so it can be ramped safely
+and rolled back instantly. **No breaking change goes straight to enforcing.**
+
+**The three-state ramp (off → observe → enforce):**
+
+1. **Off** — the new code path is not active. Default for every new toggle, so merging + deploying
+   changes nothing.
+2. **Observe (dark launch)** — the new path runs and is **measured**, but does not change behaviour:
+   it emits a metric (and a log) for what it *would* do. You ramp forward only on evidence.
+3. **Enforce** — the change takes effect. Reached only after the observe metrics say it is safe, and
+   reversible by flipping the toggle back.
+
+**Rules:**
+
+- **Measure before you enforce.** A dark launch that only logs is not enough — emit a Prometheus
+  counter so the decision is data-driven and alertable. You cannot ramp what you cannot see.
+- **Toggles are runtime + per-environment** (env vars driven by fasit `Feature.yaml`), so each
+  environment ramps independently and any toggle is an instant kill switch — no redeploy of code.
+- **Fail closed only after enforce; fail open (and count) while observing.**
+- **Name the metric after the decision** it informs, and alert on the "would-break" series reaching
+  a safe threshold (usually zero) as the go/no-go signal.
+
+**Applied to the current changes:**
+
+| Change | Off | Observe (dark launch) | Enforce | Go/no-go signal |
+| --- | --- | --- | --- | --- |
+| **PSK auth** | no keys configured | keys set, `BIFROST_AUTH_ENFORCED=false` (accept-then-enforce) — unauthenticated calls allowed **and counted** | `BIFROST_AUTH_ENFORCED=true` — 401 on missing key | `bifrost_api_auth_requests_total{outcome="unauthenticated_allowed"}` → 0 |
+| **Reconciler** | `BIFROST_RECONCILER_ENABLED=false` | enabled + `BIFROST_RECONCILER_DRY_RUN=true` — computes the diff, **counts** what it would change, patches nothing | `BIFROST_RECONCILER_DRY_RUN=false` — converges | `bifrost_reconciler_actions_total{action="would_change"}` understood/expected |
+
+Bifrost exposes `/metrics` (unauthenticated, scraped by the existing ServiceMonitor) for the API-side
+counters; the reconciler manager exposes its own counters on its metrics port. Build a dashboard per
+ramp before enabling observe mode.
+
 ## 7. Risks & mitigations
 
 - **Reconciler fighting unleasherator / release-channel controller.** Use server-side apply with a

--- a/docs/RECONCILER_IMPROVEMENT_PLAN.md
+++ b/docs/RECONCILER_IMPROVEMENT_PLAN.md
@@ -1,0 +1,332 @@
+# Bifrost: Adversarial Review & Reconciler Improvement Plan
+
+_Status: proposal • Scope: `nais/bifrost` • Companion: `nais/unleasherator`_
+
+## 1. Problem statement
+
+Bifrost is described as "responsible for reconciling the Unleash instances according to the config
+they are supposed to have." **It does not reconcile.** It is a synchronous Gin CRUD API: desired
+config is rendered into an `Unleash` CR (and a Cloud SQL database + user + secret + FQDN
+NetworkPolicy) **only** on `POST`/`PUT`, and torn down **only** on `DELETE`. There is no control
+loop, so:
+
+- **Global config drift is permanent.** Ingress host, SQL instance CIDR, cloud-sql-proxy sidecar
+  image, OAuth audience, FQDN egress list, and resource limits are baked into each CR at write time
+  (`unleash_repository.go:591-758`). When any of these change, existing instances keep the stale
+  value forever. Only the ingress **class** is ever re-applied (`ReconcileIngressClasses`).
+- **Manual/out-of-band drift is never corrected.** If an admin edits an `Unleash` CR or deletes the
+  credentials secret, nothing repairs it.
+- **Partial failures orphan real resources.** Provisioning spans Postgres + Kubernetes with no
+  transaction, rollback, or idempotency, so failures leak Cloud SQL databases/users/secrets.
+
+The one component named "reconciler" (`pkg/application/migration/reconciler.go`) is a **one-shot,
+in-memory batch migration** run once at startup — not a converging control loop.
+
+The fix is to turn bifrost into a proper **controller-runtime reconciler**: the API records desired
+state; a reconcile loop continuously converges actual → desired (CR spec + child resources +
+database), with ownership-based GC, idempotent "ensure" operations, finalizers, status, and leader
+election.
+
+---
+
+## 1a. Dependencies & trust boundary (nais-api + PSK)
+
+**Upstream (who calls bifrost):** `nais-api` is the **sole consumer** of the bifrost REST API. It
+uses the generated `pkg/bifrostclient` configured with `BifrostAPIURL`
+(`nais/api:internal/unleash/bifrost.go`, `internal/cmd/api/api.go`), and consumes:
+`GET /v1/releasechannels[/:name]`, `GET/POST /v1/unleash`, `GET/PUT/DELETE /v1/unleash/:name`
+(instance CRUD + an "issue checker" that reads instance state). **nais-api authenticates end users
+and enforces team ownership/authorization**; bifrost is an internal backend behind a NetworkPolicy.
+
+**Downstream (what bifrost drives):**
+- **Kubernetes API (management cluster):** creates/updates `Unleash` CRs (unleasherator `api/v1`
+  types), FQDN NetworkPolicies, credential Secrets; reads ReleaseChannels.
+- **unleasherator operator:** actually realizes `Unleash` CRs and owns ReleaseChannel reconciliation.
+  Bifrost must not fight it — use a distinct field manager and only own bifrost-rendered fields.
+- **Google Cloud SQL Admin API:** databases/users on a shared SQL instance.
+- **GitHub API:** image tags for version listing.
+
+**Auth model — pre-shared key (decided):** bifrost trusts a single privileged caller (nais-api), so
+auth is a **pre-shared key held in fasit**, injected as env into both sides — bifrost validates the
+header; nais-api sends it via a `bifrostclient` `RequestEditorFn`. Terraform already manages a
+`bifrost_teams_api_key` fasit value in `nais-terraform-modules/modules/management/bifrost.tf`; add a
+sibling `bifrost_api_key` the same way and wire it to **both** bifrost and nais-api.
+
+**Consequence for the review:** because nais-api is the trusted authority for team scoping, bifrost
+does **not** need per-team authorization. The "tenant isolation" findings (S2/S3) are therefore
+**not** bugs to fix in bifrost — they are a documented trust boundary: bifrost relies on nais-api +
+PSK + NetworkPolicy. What bifrost still owes is: (1) the PSK gate (S1), (2) strict input validation
+of everything nais-api passes (names, allowed_teams), and (3) not returning secrets even to a
+trusted caller (S5).
+
+**This is a coordinated, cross-repo change** (`nais/bifrost` + `nais/api` + `nais-terraform-modules`)
+and must be sequenced (accept-then-enforce) — see Phase 0 and the "PSK auth" issue.
+
+---
+
+## 2. Adversarial review — findings
+
+Verified by direct code reading. Severity is operational impact.
+
+### 2.1 Security (fix before anything else)
+
+| # | Severity | Finding | Location |
+|---|----------|---------|----------|
+| S1 | **critical** | **No authentication** on any endpoint. Only a NetworkPolicy stands between a caller and full instance CRUD (each provisions a DB + workload). **Fix = PSK** (§1a): validate a fasit-shared key that only nais-api holds. | `server.go:151-175` |
+| S2 | ~~critical~~ **by-design** | **No per-team authz in bifrost.** Reframed given §1a: nais-api is the trusted authority for team scoping, so this is a documented trust boundary, not a bifrost bug. Once S1 (PSK) lands, "any caller" collapses to "nais-api only". Keep tenant enforcement in nais-api. | `handlers/unleash.go:57,81,187,303` |
+| S3 | ~~high~~ **by-design + validate** | **Federation allowlist set by the caller.** Authorizing who may edit `allowed_teams`/`allowed_clusters` is nais-api's job. Bifrost should still **validate** the values (defense-in-depth), but not treat this as its authz surface. | `handlers/unleash.go:230-240` |
+| S4 | high | **Weak randomness for the federation nonce** — `utils.RandomString` uses `math/rand` (~41 bits, predictable). DB passwords correctly use `crypto/rand`; the nonce is inconsistent. | `utils/strings.go:42`, consumed `unleash_repository.go:598` |
+| S5 | medium | **Info leak** — `GET` returns the raw CRD including `Spec.Federation.SecretNonce`; bind/validation errors are echoed verbatim. | `handlers/unleash.go:97,121` |
+| S6 | medium | **No quota / rate limit** → cost-amplification DoS (unbounded DB + workload creation), amplified by S1. | `handlers/unleash.go:112`, `service.go:72` |
+| S7 | medium | **Weak name validation** — no length bound, dots allowed; a valid-API but invalid-k8s/DB name fails mid-sequence and orphans resources (see R1). | `domain/unleash/config.go:154` |
+
+### 2.2 Resource lifecycle & correctness (the "not a reconciler" damage)
+
+| # | Severity | Finding | Location |
+|---|----------|---------|----------|
+| R1 | **critical** | **`Create` has no rollback.** DB → user → secret → netpol → CR run sequentially; any later failure orphans the earlier Cloud SQL DB/user/secret/netpol. Non-idempotent `Create` calls mean retries hit `AlreadyExists` and wedge. | `service.go:72-92`, `manager.go:52,116`, `unleash_repository.go:420` |
+| R2 | **critical** | **`Delete` aborts on first error, CR-first.** A transient secret-delete failure skips DB/user deletion; because the CR is already gone, the handler's `Get` guard then 404s, so the leaked DB/user can never be reaped via the API. | `service.go:145-163`, `handlers/unleash.go:307` |
+| R3 | high | **Cloud SQL operations are async but never awaited.** Every `.Do()` discards the returned `*admin.Operation`, so create "succeeds" before the DB exists (pod connects too early) and user-delete races the still-running DB-drop (orphaned user). | `manager.go:57,83,131,147` |
+| R4 | high | **`Update` rebuilds the whole object**, preserving only 4 metadata fields — clobbering finalizers, ownerReferences, labels, annotations, and resetting `Size` to 1 on every PUT. | `unleash_repository.go:187-193,617-622` |
+| R5 | high | **PUT round-trip loss** — `LogLevel`, `DatabasePoolMax`, `DatabasePoolIdleTimeoutMs` are read only from the request body; omitted → reset to builder defaults. `LoadConfigFromCRD` (which would preserve them) is unused by the HTTP path. | `handlers/unleash.go:218`, `dto/unleash.go:58-64` |
+| R6 | medium | **Update fails if the FQDN netpol is missing** (Get-then-Update, no create-if-absent), so a manually-deleted or pre-feature netpol makes the instance permanently un-updatable. | `unleash_repository.go:428-509` |
+| R7 | medium | **Children not owner-referenced.** FQDN netpol and DB secret have no `OwnerReference` to the CR, so `kubectl delete unleash` orphans them and cascade GC is impossible. | `unleash_repository.go:354-365`, `manager.go:100` |
+| R8 | low | **APIVersion mismatch** — list/get use `unleasherator.nais.io/v1`; the real group is `unleash.nais.io/v1`. Inert with the typed client, latent under unstructured/serialization. | `unleash_repository.go:45,85,118` vs `:615` |
+
+### 2.3 The existing "migration reconciler" (batch, not a loop)
+
+| # | Severity | Finding | Location |
+|---|----------|---------|----------|
+| M1 | high | **In-memory, one-shot, no resume.** State lives in a `sync.Map`; a restart mid-migration loses progress, and an instance left mid-flight is silently dropped (no longer matches the custom-version filter) with no health verification. | `migration/reconciler.go:24,73-131` |
+| M2 | high | **Shutdown misclassified as health failure** → triggers rollback on the already-cancelled context, which then fails → `statusRollbackFailed` + "manual intervention" alarms for a normal SIGTERM. | `reconciler.go:191-198`, `common.go:151` |
+| M3 | high | **Stale-Ready false positive.** `waitForHealthy` accepts the old generation's `Ready` conditions immediately after Update (no `observedGeneration` gate), marking a possibly-broken migration "completed". | `common.go:164`, unleasherator `IsReady()` |
+| M4 | high | **Lossy rollback.** Rollback rebuilds the whole CR from a lossy `Config` round-trip (`CustomImage` split keeps only the tag; repo/name/size/resources reset to hardcoded defaults). | `reconciler.go:207-242`, `unleash_repository.go:548-579,752` |
+| M5 | medium | **Transient errors are terminal** (any Get/Update error → `statusFailed`, no retry/backoff); `waitForHealthy` never checks at t=0 and self-times-out when `timeout ≤ pollInterval`. | `reconciler.go:149-187`, `common.go:146-155` |
+| M6 | low | **No leader election** — correctness depends entirely on `replicas: 1`; a surge rollout runs two reconcilers over the same instances. | `server.go:247-270` |
+
+### 2.4 Operational robustness
+
+| # | Severity | Finding | Location |
+|---|----------|---------|----------|
+| O1 | medium | **HTTP server ignores configured timeouts** (`Read`/`Write`/`Idle` parsed but never applied) → Slowloris exposure. | `server.go:279` |
+| O2 | medium | **Startup goroutines leak / not awaited**; ingress-reconcile goroutine uses `context.Background()` and isn't cancelled; serve goroutine `Fatal`s and bypasses cleanup. | `server.go:233,287,294-301` |
+| O3 | medium | **GitHub tags client** is unauthenticated, no timeout/context/cache, no body limit → 60 req/hr rate limit breaks provisioning; picks `tags[0]` not the newest release (`ReleaseTime` never used for ordering). | `github/tags.go:21`, `domain/unleash/config.go:115` |
+| O4 | low | **`GinMiddleware` variable shadow** — inner `c *gin.Context` shadows the `*Config` receiver, so `c.Set("config", c)` stores the gin context, not the config. | `config.go:152-157` |
+| O5 | low | **`godotenv` fragile string match**; `New()` panics on missing required config; `DebugMode` is dead config while the logger is hardcoded to Debug in prod (secret-leak risk). | `config.go:136,160-172`, `server.go:82` |
+| O6 | low | **Always-OK `/healthz`, no readiness** — a broken kube/GCP client still reports healthy. | `server.go:155` |
+
+---
+
+## 3. Target architecture
+
+Split bifrost into two cooperating roles inside one binary:
+
+```
+                 writes desired intent                 converges actual → desired
+   HTTP client ───────────────────────►  API layer ───────────────────────► Reconciler (control loop)
+   (IAP/JWT)      (authn + authz +        (thin: validate,                    watch Unleash CRs +
+                   quota + validation)     persist intent,                     periodic resync
+                                           return 202)                         │
+                                                                               ├─ render desired spec (global cfg + intent)
+                                                                               ├─ server-side apply Unleash CR
+                                                                               ├─ ensure FQDN netpol (owned)
+                                                                               ├─ ensure Cloud SQL db/user/secret (owned, awaited)
+                                                                               └─ write status/conditions
+```
+
+- **The API stops doing side effects.** It authenticates, authorizes, validates, records desired
+  intent, and returns `202 Accepted`. It never touches Cloud SQL directly.
+- **The reconciler owns all convergence.** It runs on CR events **and** a periodic resync (e.g. 10m),
+  so global-config changes propagate to every instance automatically and drift self-heals.
+- **Everything is idempotent "ensure".** Create/update collapse into one apply path; there is no
+  separate imperative create vs update.
+
+### 3.1 Where does desired state live?
+
+Per-instance intent (version source, allowed teams/clusters, log level, DB pool, nonce) currently
+lives tangled inside the rendered `Unleash` spec, which is why `Update` and rollback are lossy.
+Two options:
+
+- **Option A — intent annotation on the `Unleash` CR (recommended first step).** Store the canonical
+  intent as a single JSON blob under a bifrost-owned annotation
+  (`bifrost.nais.io/desired-state`) plus a `app.kubernetes.io/managed-by: bifrost` label. The
+  reconciler reads the annotation (non-lossy source of truth), renders the full spec deterministically,
+  and server-side-applies. **No new CRD, minimal migration, immediate drift correction.**
+- **Option B — dedicated `BifrostUnleash` CRD (cleaner long-term).** The API writes a small
+  desired-state CR; a reconciler renders the `unleasherator` `Unleash` CR + DB from it. Best
+  separation of concerns (bifrost = tenant/fleet intent, unleasherator = k8s realization) but a
+  heavier migration and a two-hop reconcile.
+
+**Recommendation:** ship Option A now (it removes R4/R5/M4 lossiness immediately and needs no CRD
+rollout), and keep Option B as a follow-up once the reconcile loop is proven.
+
+---
+
+## 4. Reconciler design (Option A)
+
+Use `sigs.k8s.io/controller-runtime` (already a dependency) with a `Manager` embedded in the bifrost
+process.
+
+```go
+// One reconciler, keyed by Unleash CR name; selector-filtered to bifrost-managed instances.
+func (r *UnleashReconciler) Reconcile(ctx, req) (ctrl.Result, error) {
+    cr := get(req)                                 // NotFound → nothing to do
+    if !managedByBifrost(cr) { return noRequeue }  // label filter
+    if beingDeleted(cr) { return r.finalize(ctx, cr) }
+    ensureFinalizer(cr)
+
+    intent := parseIntent(cr)                      // from bifrost.nais.io/desired-state annotation
+    desired := render(r.globalConfig, intent)      // the SINGLE shared render fn (also used by API preview)
+
+    // 1. Database (idempotent + awaited)
+    ensureDatabase(ctx, intent.Name)               // get-or-create, poll Operation → DONE
+    ensureDatabaseUser(ctx, intent.Name)           // get-or-create; rotate only on explicit request
+    ensureCredentialsSecret(ctx, intent.Name, ...) // CreateOrUpdate, OwnerReference=cr
+
+    // 2. Kubernetes objects (server-side apply, preserve foreign fields)
+    applyUnleashSpec(ctx, cr, desired.Spec)        // patch only bifrost-owned fields
+    ensureFQDNNetworkPolicy(ctx, cr, desired.Netpol) // CreateOrUpdate, OwnerReference=cr
+
+    // 3. Status
+    setConditions(cr, ...)                         // Ready/Degraded + observedGeneration
+    return requeueAfter(resyncInterval)            // periodic re-render → global-config drift heals
+}
+```
+
+Key design rules:
+
+1. **Idempotent ensure everywhere.** Replace `Insert`/`Create` with get-or-create (treat
+   `AlreadyExists`/409 as success) and `controllerutil.CreateOrUpdate` / server-side apply. Fixes
+   R1, R6, and the M-series retry problems.
+2. **Await Cloud SQL operations.** Capture the returned `*admin.Operation` and poll
+   `operations.Get` until `DONE` (bounded by ctx timeout) before advancing to the dependent step.
+   Fixes R3.
+3. **Owner references on all children** (secret, FQDN netpol) → cascade GC; delete becomes mostly
+   "let Kubernetes GC" plus a finalizer for the external Cloud SQL DB/user. Fixes R2, R7.
+4. **Finalizer for external state.** A `bifrost.nais.io/finalizer` runs best-effort DB/user/secret
+   teardown (accumulate errors, `IgnoreNotFound`, delete DB before user) and only removes the
+   finalizer once external cleanup succeeds. Fixes R2.
+5. **Server-side apply / field-scoped patch** so bifrost only owns the fields it renders and never
+   clobbers finalizers, ownerReferences, labels, or `Size` set by unleasherator or humans. Fixes R4/R5.
+6. **Generation-aware health.** Gate "ready after change" on `status.observedGeneration ≥` the
+   generation returned by the apply, not stale conditions. Fixes M3.
+7. **Leader election** (`manager.Options{LeaderElection: true}`) so HA/rollouts are safe. Fixes M6.
+8. **Migrations become reconcile policy, not a batch job.** Version/channel migration is expressed
+   as a transformation of the desired intent, applied idempotently by the same loop, checkpointed on
+   the CR (annotation/condition), resumable across restarts, with rollback via re-applying the stored
+   prior intent under a **fresh** bounded context. Fixes M1/M2/M4/M5.
+
+---
+
+## 5. Phased implementation plan
+
+Each phase is independently shippable and leaves the system better than before.
+
+### Phase 0 — Security & orphan stop-gap (urgent, no architecture change)
+- **S1 (PSK auth — cross-repo, coordinated):**
+  1. `nais-terraform-modules`: add a `bifrost_api_key` fasit value (mirror `bifrost_teams_api_key`),
+     wired to **both** the bifrost and nais-api deployments.
+  2. `bifrost`: add an auth middleware (in front of `/v1/*`, exempting `/healthz`, `/readyz`,
+     `/openapi.json`) that compares an `Authorization`/`X-API-Key` header against the configured key
+     using a **constant-time** compare; support a set of keys for rotation. Ship in **accept-then-
+     enforce** mode: first release logs-but-allows missing keys (metric on unauthenticated calls),
+     second release fails closed once nais-api is confirmed sending it.
+  3. `nais-api`: add a `bifrostclient` `RequestEditorFn` that sets the header from its fasit-injected
+     config. Deploy **before** bifrost flips to enforce.
+- **S5:** return a response DTO that omits `SecretNonce` and other secret material; stop echoing raw
+  bind/validation errors to the client (log server-side).
+- **S7 / input validation:** enforce strict DNS-1123-label + max-length on instance name before any
+  resource is created; validate `allowed_teams`/`allowed_clusters` values.
+- (S2/S3 need **no bifrost code** beyond S1+validation — see §1a; note them in the nais-api trust doc.)
+- **S4:** reimplement `utils.RandomString` on `crypto/rand`; lengthen the nonce.
+- **R1/R2:** make `Create` roll back on failure (deferred best-effort teardown) and `Delete`
+  best-effort + `IgnoreNotFound` + DB-before-user, decoupled from the CR `Get` guard.
+- **R3:** await Cloud SQL operations.
+- **O1/O2/O4/O5:** apply server timeouts; single root context + `WaitGroup` for graceful shutdown;
+  fix the `GinMiddleware` shadow; `errors.Is(os.ErrNotExist)` for godotenv; drive log level from config.
+
+### Phase 1 — Idempotent, ownership-based primitives (prepares for the loop)
+- Convert `dbManager` and `unleash_repository` mutations to idempotent **ensure** operations
+  (get-or-create, `CreateOrUpdate`, server-side apply). Fixes R1/R6 structurally.
+- Set **OwnerReferences** on secret + FQDN netpol (R7). Add a finalizer for Cloud SQL teardown.
+- Extract a single **`render(globalConfig, intent) → (Spec, Netpol)`** function used by both the API
+  (for preview/validation) and the reconciler — one source of truth for rendering.
+- Introduce the **intent annotation** (`bifrost.nais.io/desired-state`) + `managed-by` label; write it
+  on create/update. Make `LoadConfigFromCRD` read the annotation (non-lossy). Fixes R4/R5/M4.
+- Fix R8 (single canonical GroupVersion), O3 (hardened, cached, authenticated GitHub client + sort by
+  `ReleaseTime`), O6 (`/readyz` with dependency checks).
+
+### Phase 2 — Introduce the reconciler
+- Embed a controller-runtime `Manager` with **leader election**; register the `UnleashReconciler`
+  watching `Unleash` CRs filtered by the `managed-by` label, owning secret + netpol, with periodic
+  resync (drift correction).
+- Move all convergence (render → apply → ensure DB/netpol/secret → status) into `Reconcile`.
+- **The API becomes thin:** validate + authz + persist intent (create/patch the CR annotation) +
+  `202`. Remove side effects from the request path (fixes S6 blast radius and the create/delete
+  race). Report status via the CR conditions the reconciler writes.
+
+### Phase 3 — Fold migrations into the loop, retire the batch
+- Express version/channel migration as an intent transformation applied idempotently by the
+  reconciler, checkpointed on the CR, resumable, with generation-aware health gating and
+  fresh-context rollback. Delete `pkg/application/migration/*` one-shot batch once parity is proven.
+
+### Phase 4 (optional) — Dedicated `BifrostUnleash` CRD (Option B)
+- If the annotation-as-intent proves limiting, promote intent to a first-class CRD for cleaner
+  API/validation/RBAC and a proper `kubectl` surface.
+
+---
+
+## 6. Testing & rollout
+
+- **Unit:** `render()` golden tests; ensure-idempotency (apply twice → no diff); finalizer teardown
+  with injected failures; Cloud SQL operation-await with a fake operations service.
+- **envtest:** reconcile against a real API server + fake Cloud SQL/GitHub; drift tests (mutate a CR
+  field, assert it's corrected on resync); global-config-change test (bump proxy image → all
+  instances re-rendered); orphan test (fail mid-create → assert no leaked children).
+- **Migration parity:** run Phase 3 reconciler against a snapshot of prod-like instances; assert no
+  unintended spec diffs vs the batch migrator.
+- **Rollout:** ship Phase 0 immediately (security). Gate the reconciler behind a feature flag
+  (`BIFROST_RECONCILER_ENABLED`, default off); enable in a non-prod tenant first; watch drift/apply
+  metrics; then enable in prod with `replicas: 1` until leader election lands, then scale.
+
+## 7. Risks & mitigations
+
+- **Reconciler fighting unleasherator / release-channel controller.** Use server-side apply with a
+  distinct field manager and only own bifrost-rendered fields; never write status or fields owned by
+  unleasherator. Verify against issue set #753–#756 (unleasherator rollout controller).
+- **Mass re-render on first enable** (global config differs from baked-in values) could restart many
+  pods at once. Mitigate with a bounded work rate / maxConcurrentReconciles and a canary tenant.
+- **Intent-annotation migration** for existing instances: backfill the annotation from the current
+  spec once (best-effort `LoadConfigFromCRD`) before enabling strict re-render.
+- **Auth rollout** (S1/S2) may break existing unauthenticated clients — coordinate with callers;
+  ship behind the ingress/IAP that already fronts it, then enforce in code.
+
+---
+
+## 8. Issue structure — one PRD or several?
+
+**Recommendation: multiple, as an epic + focused issues** (not one mega-issue). The work has
+different urgencies, owners, and blast radii, and one item is cross-repo:
+
+- **Epic / PRD** (this document): "Turn bifrost into a reconciler" — the umbrella, links the children.
+- **Issue A — PSK authentication (cross-repo, urgent).** Own issue because it spans
+  `nais/bifrost` + `nais/api` + `nais-terraform-modules` and needs the accept-then-enforce sequence.
+  Blocks nothing but is the highest-priority security fix.
+- **Issue B — provisioning correctness / stop orphaning (urgent).** R1–R3: rollback-on-failure,
+  best-effort idempotent delete, await Cloud SQL operations. Pure bifrost, shippable now.
+- **Issue C — introduce the reconciler (epic-sized).** Phases 1–2: idempotent ensure primitives,
+  owner references, shared `render()`, intent annotation, the controller-runtime loop, leader
+  election. The architectural core.
+- **Issue D — fold migrations into the loop.** Phase 3; depends on C.
+- **Issue E — operational hardening (low-risk bundle).** O1–O6 + S4 (crypto nonce) + O3 (GitHub
+  client) — can be done independently and in parallel.
+
+Rationale: A must be coordinated with nais-api and can't sit inside a bifrost-only epic; B is a
+fast, high-value correctness fix that shouldn't wait for the reconciler; C/D are the large
+architectural change; E is cleanup. Splitting keeps each independently reviewable, assignable, and
+schedulable.
+
+---
+
+_Appendix: all findings above were verified by direct code reading of `nais/bifrost` at the current
+checkout. Line numbers may shift as the code evolves._

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/oasdiff/yaml v0.1.0 // indirect
@@ -107,7 +108,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/pkg/api/http/v1/handlers/unleash.go
+++ b/pkg/api/http/v1/handlers/unleash.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nais/bifrost/pkg/domain/releasechannel"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Unleash type alias for swagger documentation
@@ -304,23 +305,34 @@ func (h *UnleashHandler) DeleteInstance(c *gin.Context) {
 	ctx := c.Request.Context()
 	name := c.Param("name")
 
-	_, err := h.service.Get(ctx, name)
-	if err != nil {
-		h.logger.WithContext(ctx).WithError(err).WithField("name", name).Warn("Instance not found")
-		c.JSON(http.StatusNotFound, ErrorResponse{
-			Error:      "not_found",
-			Message:    "Instance not found",
-			Details:    map[string]string{"name": name},
-			StatusCode: http.StatusNotFound,
+	_, getErr := h.service.Get(ctx, name)
+	if getErr != nil && !apierrors.IsNotFound(getErr) {
+		h.logger.WithContext(ctx).WithError(getErr).WithField("name", name).Error("Failed to look up instance for deletion")
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error:      "deletion_failed",
+			StatusCode: http.StatusInternalServerError,
 		})
 		return
 	}
 
+	// Run best-effort teardown even when the CRD is already gone, so a database,
+	// user, or secret orphaned by a prior partial failure is still reaped.
 	if err := h.service.Delete(ctx, name); err != nil {
 		h.logger.WithContext(ctx).WithError(err).WithField("name", name).Error("Failed to delete instance")
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error:      "deletion_failed",
 			StatusCode: http.StatusInternalServerError,
+		})
+		return
+	}
+
+	// Preserve the existing 404 contract when nothing was there to begin with.
+	if apierrors.IsNotFound(getErr) {
+		c.JSON(http.StatusNotFound, ErrorResponse{
+			Error:      "not_found",
+			Message:    "Instance not found",
+			Details:    map[string]string{"name": name},
+			StatusCode: http.StatusNotFound,
 		})
 		return
 	}

--- a/pkg/application/unleash/service.go
+++ b/pkg/application/unleash/service.go
@@ -2,12 +2,19 @@ package unleash
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/nais/bifrost/pkg/config"
 	"github.com/nais/bifrost/pkg/domain/unleash"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+// cleanupTimeout bounds best-effort rollback/teardown, which runs on a context
+// detached from the request so it completes even if the caller disconnected.
+const cleanupTimeout = 5 * time.Minute
 
 // IService defines the interface for unleash instance management operations
 type IService interface {
@@ -68,38 +75,83 @@ func (s *Service) GetCRD(ctx context.Context, name string) (*unleashv1.Unleash, 
 	return s.repository.GetCRD(ctx, name)
 }
 
-// Create creates a new unleash instance with its database and resources
-func (s *Service) Create(ctx context.Context, config *unleash.Config) (*unleashv1.Unleash, error) {
+// Create creates a new unleash instance with its database and resources.
+//
+// Provisioning spans Cloud SQL (database + user) and Kubernetes (secret + CRD)
+// with no cross-system transaction, so any step failing partway used to orphan
+// the resources created before it. Create now rolls back everything it created
+// on failure, so a failed create leaves no orphaned database, user, secret, or
+// CRD behind. Rollback runs on a detached, bounded context so it completes even
+// if the request context was cancelled.
+func (s *Service) Create(ctx context.Context, config *unleash.Config) (crd *unleashv1.Unleash, err error) {
+	name := config.Name
+
+	var dbCreated, userCreated, secretCreated, crdCreated bool
+	defer func() {
+		if err == nil {
+			return
+		}
+		cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+		defer cancel()
+		log := s.logger.WithContext(ctx).WithField("instance", name)
+		log.WithError(err).Warn("Create failed, rolling back partially-created resources")
+
+		// Reverse order of creation; drop the database before the user it owns.
+		if crdCreated {
+			if e := s.repository.Delete(cctx, name); e != nil && !apierrors.IsNotFound(e) {
+				log.WithError(e).Error("Rollback: failed to delete unleash CRD")
+			}
+		}
+		if secretCreated {
+			if e := s.dbManager.DeleteSecret(cctx, name); e != nil {
+				log.WithError(e).Error("Rollback: failed to delete credentials secret")
+			}
+		}
+		if dbCreated {
+			if e := s.dbManager.DeleteDatabase(cctx, name); e != nil {
+				log.WithError(e).Error("Rollback: failed to delete database")
+			}
+		}
+		if userCreated {
+			if e := s.dbManager.DeleteDatabaseUser(cctx, name); e != nil {
+				log.WithError(e).Error("Rollback: failed to delete database user")
+			}
+		}
+	}()
+
 	// Create database
-	if err := s.dbManager.CreateDatabase(ctx, config.Name); err != nil {
+	if err = s.dbManager.CreateDatabase(ctx, name); err != nil {
 		return nil, err
 	}
+	dbCreated = true
 
 	// Create database user
-	password, err := s.dbManager.CreateDatabaseUser(ctx, config.Name)
-	if err != nil {
+	var password string
+	if password, err = s.dbManager.CreateDatabaseUser(ctx, name); err != nil {
 		return nil, err
 	}
+	userCreated = true
 
 	// Create secret with credentials
-	if err := s.dbManager.CreateSecret(ctx, config.Name, password); err != nil {
+	if err = s.dbManager.CreateSecret(ctx, name, password); err != nil {
 		return nil, err
 	}
+	secretCreated = true
 
 	// Create unleash instance in Kubernetes
-	if err := s.repository.Create(ctx, config); err != nil {
+	if err = s.repository.Create(ctx, config); err != nil {
 		return nil, err
 	}
+	crdCreated = true
 
 	// Retrieve the created CRD to return
-	crd, err := s.getCRD(ctx, config.Name)
-	if err != nil {
+	if crd, err = s.getCRD(ctx, name); err != nil {
 		return nil, err
 	}
 
 	s.logger.WithContext(ctx).WithFields(logrus.Fields{
 		"operation":      "create_unleash",
-		"instance":       config.Name,
+		"instance":       name,
 		"version_source": config.VersionSource(),
 	}).Info("Created unleash instance")
 
@@ -141,25 +193,34 @@ func (s *Service) Update(ctx context.Context, config *unleash.Config) (*unleashv
 	return crd, nil
 }
 
-// Delete deletes an unleash instance and its resources
+// Delete deletes an unleash instance and its resources.
+//
+// Deletion is best-effort and idempotent: every step is attempted regardless of
+// earlier failures (errors are aggregated), and each underlying operation treats
+// an already-absent resource as success. This means a transient failure in one
+// step no longer skips the remaining teardown and orphans the database/user, and
+// the call can be safely retried to reap anything left behind.
 func (s *Service) Delete(ctx context.Context, name string) error {
-	// Delete in reverse order of creation
-	if err := s.repository.Delete(ctx, name); err != nil {
-		return err
-	}
+	var errs []error
 
+	// Delete the CRD first to stop the workload, then its credentials secret.
+	if err := s.repository.Delete(ctx, name); err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, err)
+	}
 	if err := s.dbManager.DeleteSecret(ctx, name); err != nil {
-		return err
+		errs = append(errs, err)
 	}
-
-	// Delete database before user to avoid dependency errors
-	// (PostgreSQL won't let you drop a user that owns database objects)
+	// Delete the database before the user to avoid dependency errors
+	// (PostgreSQL won't let you drop a user that owns database objects).
 	if err := s.dbManager.DeleteDatabase(ctx, name); err != nil {
-		return err
+		errs = append(errs, err)
+	}
+	if err := s.dbManager.DeleteDatabaseUser(ctx, name); err != nil {
+		errs = append(errs, err)
 	}
 
-	if err := s.dbManager.DeleteDatabaseUser(ctx, name); err != nil {
-		return err
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	s.logger.WithContext(ctx).WithFields(logrus.Fields{

--- a/pkg/application/unleash/service_test.go
+++ b/pkg/application/unleash/service_test.go
@@ -54,10 +54,12 @@ func (f *fakeDBManager) DeleteDatabase(_ context.Context, _ string) error {
 	}
 	return nil
 }
+
 func (f *fakeDBManager) DeleteDatabaseUser(_ context.Context, _ string) error {
 	f.record("DeleteDatabaseUser")
 	return nil
 }
+
 func (f *fakeDBManager) DeleteSecret(_ context.Context, _ string) error {
 	f.record("DeleteSecret")
 	return nil
@@ -77,6 +79,7 @@ func (f *fakeRepo) ListCRDs(context.Context, bool) ([]unleashv1.Unleash, error) 
 func (f *fakeRepo) Get(context.Context, string) (*unleash.Instance, error) {
 	return &unleash.Instance{}, nil
 }
+
 func (f *fakeRepo) GetCRD(context.Context, string) (*unleashv1.Unleash, error) {
 	return &unleashv1.Unleash{}, nil
 }

--- a/pkg/application/unleash/service_test.go
+++ b/pkg/application/unleash/service_test.go
@@ -1,0 +1,168 @@
+package unleash
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/nais/bifrost/pkg/config"
+	"github.com/nais/bifrost/pkg/domain/unleash"
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/sirupsen/logrus"
+)
+
+// fakeDBManager records calls and can be told to fail a specific step.
+type fakeDBManager struct {
+	failCreateDB, failCreateUser, failCreateSecret bool
+	failDeleteDB                                   bool
+
+	calls []string
+}
+
+func (f *fakeDBManager) record(c string)      { f.calls = append(f.calls, c) }
+func (f *fakeDBManager) called(c string) bool { return slices.Contains(f.calls, c) }
+
+func (f *fakeDBManager) CreateDatabase(_ context.Context, _ string) error {
+	f.record("CreateDatabase")
+	if f.failCreateDB {
+		return errors.New("boom db")
+	}
+	return nil
+}
+
+func (f *fakeDBManager) CreateDatabaseUser(_ context.Context, _ string) (string, error) {
+	f.record("CreateDatabaseUser")
+	if f.failCreateUser {
+		return "", errors.New("boom user")
+	}
+	return "pw", nil
+}
+
+func (f *fakeDBManager) CreateSecret(_ context.Context, _ string, _ string) error {
+	f.record("CreateSecret")
+	if f.failCreateSecret {
+		return errors.New("boom secret")
+	}
+	return nil
+}
+
+func (f *fakeDBManager) DeleteDatabase(_ context.Context, _ string) error {
+	f.record("DeleteDatabase")
+	if f.failDeleteDB {
+		return errors.New("boom delete db")
+	}
+	return nil
+}
+func (f *fakeDBManager) DeleteDatabaseUser(_ context.Context, _ string) error {
+	f.record("DeleteDatabaseUser")
+	return nil
+}
+func (f *fakeDBManager) DeleteSecret(_ context.Context, _ string) error {
+	f.record("DeleteSecret")
+	return nil
+}
+
+// fakeRepo records calls and can fail Create.
+type fakeRepo struct {
+	failCreate bool
+	calls      []string
+}
+
+func (f *fakeRepo) record(c string)      { f.calls = append(f.calls, c) }
+func (f *fakeRepo) called(c string) bool { return slices.Contains(f.calls, c) }
+
+func (f *fakeRepo) List(context.Context, bool) ([]*unleash.Instance, error)     { return nil, nil }
+func (f *fakeRepo) ListCRDs(context.Context, bool) ([]unleashv1.Unleash, error) { return nil, nil }
+func (f *fakeRepo) Get(context.Context, string) (*unleash.Instance, error) {
+	return &unleash.Instance{}, nil
+}
+func (f *fakeRepo) GetCRD(context.Context, string) (*unleashv1.Unleash, error) {
+	return &unleashv1.Unleash{}, nil
+}
+func (f *fakeRepo) Update(context.Context, *unleash.Config) error { f.record("Update"); return nil }
+func (f *fakeRepo) Delete(context.Context, string) error          { f.record("Delete"); return nil }
+func (f *fakeRepo) Create(_ context.Context, _ *unleash.Config) error {
+	f.record("Create")
+	if f.failCreate {
+		return errors.New("boom crd")
+	}
+	return nil
+}
+
+func newTestService(repo *fakeRepo, db *fakeDBManager) *Service {
+	logger := logrus.New()
+	logger.SetOutput(nopWriter{})
+	return NewService(repo, db, &config.Config{}, logger)
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestCreate_RollsBackOnCRDFailure(t *testing.T) {
+	repo := &fakeRepo{failCreate: true}
+	db := &fakeDBManager{}
+	svc := newTestService(repo, db)
+
+	_, err := svc.Create(context.Background(), &unleash.Config{Name: "team-a"})
+	if err == nil {
+		t.Fatal("expected error when CRD create fails")
+	}
+
+	// All three DB-side resources were created, so all three must be rolled back.
+	for _, want := range []string{"DeleteDatabase", "DeleteDatabaseUser", "DeleteSecret"} {
+		if !db.called(want) {
+			t.Errorf("rollback did not call %s (calls: %v)", want, db.calls)
+		}
+	}
+}
+
+func TestCreate_RollsBackOnSecretFailure(t *testing.T) {
+	repo := &fakeRepo{}
+	db := &fakeDBManager{failCreateSecret: true}
+	svc := newTestService(repo, db)
+
+	_, err := svc.Create(context.Background(), &unleash.Config{Name: "team-a"})
+	if err == nil {
+		t.Fatal("expected error when secret create fails")
+	}
+
+	// DB + user were created and must be rolled back; the CRD was never created.
+	if !db.called("DeleteDatabase") || !db.called("DeleteDatabaseUser") {
+		t.Errorf("expected db + user rollback, calls: %v", db.calls)
+	}
+	if repo.called("Delete") {
+		t.Errorf("CRD was never created; it must not be deleted in rollback")
+	}
+}
+
+func TestCreate_NoRollbackOnSuccess(t *testing.T) {
+	repo := &fakeRepo{}
+	db := &fakeDBManager{}
+	svc := newTestService(repo, db)
+
+	if _, err := svc.Create(context.Background(), &unleash.Config{Name: "team-a"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, unwanted := range []string{"DeleteDatabase", "DeleteDatabaseUser", "DeleteSecret"} {
+		if db.called(unwanted) {
+			t.Errorf("successful create must not roll back (%s called)", unwanted)
+		}
+	}
+}
+
+func TestDelete_BestEffortContinuesAfterFailure(t *testing.T) {
+	repo := &fakeRepo{}
+	db := &fakeDBManager{failDeleteDB: true}
+	svc := newTestService(repo, db)
+
+	err := svc.Delete(context.Background(), "team-a")
+	if err == nil {
+		t.Fatal("expected aggregated error when a delete step fails")
+	}
+	// The user delete must still run even though the database delete failed.
+	if !db.called("DeleteDatabaseUser") {
+		t.Errorf("delete aborted early; DeleteDatabaseUser not called (calls: %v)", db.calls)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,37 @@ type ServerConfig struct {
 	IdleTimeout     int    `env:"BIFROST_IDLE_TIMEOUT,default=60"`
 	GracefulTimeout int    `env:"BIFROST_GRACEFUL_TIMEOUT,default=15"`
 	TemplatesDir    string `env:"BIFROST_TEMPLATE_DIR,default=./templates"`
+	Auth            AuthConfig
+}
+
+// AuthConfig configures pre-shared-key authentication for the bifrost API.
+// The bifrost API is called only by nais-api, which authenticates end users and
+// enforces team ownership itself; bifrost only needs to authenticate that the
+// caller is the trusted service. The key is provisioned in fasit and injected
+// into both bifrost and nais-api.
+type AuthConfig struct {
+	// APIKeys is a comma-separated list of accepted pre-shared keys. Multiple
+	// values allow zero-downtime key rotation (accept old and new at once).
+	APIKeys string `env:"BIFROST_API_KEYS"`
+	// Enforced controls whether requests without a valid key are rejected. It
+	// defaults to false ("accept-then-enforce"): the first rollout logs
+	// unauthenticated calls without blocking them so nais-api can start sending
+	// the key; a later rollout flips this to true to fail closed.
+	Enforced bool `env:"BIFROST_AUTH_ENFORCED,default=false"`
+}
+
+// ParsedAPIKeys returns the configured pre-shared keys, trimmed and non-empty.
+func (a AuthConfig) ParsedAPIKeys() []string {
+	if a.APIKeys == "" {
+		return nil
+	}
+	keys := make([]string, 0)
+	for _, k := range strings.Split(a.APIKeys, ",") {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	return keys
 }
 
 type GoogleConfig struct {

--- a/pkg/infrastructure/cloudsql/manager.go
+++ b/pkg/infrastructure/cloudsql/manager.go
@@ -4,14 +4,27 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/nais/bifrost/pkg/config"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
 	admin "google.golang.org/api/sqladmin/v1beta4"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// operationPollInterval is how often we poll a Cloud SQL long-running operation.
+	operationPollInterval = 2 * time.Second
+	// operationWaitTimeout bounds how long we wait for a single Cloud SQL operation
+	// to reach DONE, so a stuck operation cannot block a caller indefinitely.
+	operationWaitTimeout = 5 * time.Minute
 )
 
 // DatabasesService interface for Cloud SQL databases operations
@@ -28,35 +41,101 @@ type UsersService interface {
 	Delete(project string, instance string) *admin.UsersDeleteCall
 }
 
+// OperationsService interface for polling Cloud SQL long-running operations.
+type OperationsService interface {
+	Get(project string, operation string) *admin.OperationsGetCall
+}
+
 // Manager handles Cloud SQL database and user lifecycle
 type Manager struct {
-	databasesClient DatabasesService
-	usersClient     UsersService
-	kubeClient      ctrl.Client
-	config          *config.Config
-	logger          *logrus.Logger
+	databasesClient  DatabasesService
+	usersClient      UsersService
+	operationsClient OperationsService
+	kubeClient       ctrl.Client
+	config           *config.Config
+	logger           *logrus.Logger
 }
 
 // NewManager creates a new Cloud SQL Manager
-func NewManager(databasesClient DatabasesService, usersClient UsersService, kubeClient ctrl.Client, config *config.Config, logger *logrus.Logger) *Manager {
+func NewManager(databasesClient DatabasesService, usersClient UsersService, operationsClient OperationsService, kubeClient ctrl.Client, config *config.Config, logger *logrus.Logger) *Manager {
 	return &Manager{
-		databasesClient: databasesClient,
-		usersClient:     usersClient,
-		kubeClient:      kubeClient,
-		config:          config,
-		logger:          logger,
+		databasesClient:  databasesClient,
+		usersClient:      usersClient,
+		operationsClient: operationsClient,
+		kubeClient:       kubeClient,
+		config:           config,
+		logger:           logger,
 	}
 }
 
-// CreateDatabase creates a new Cloud SQL database
+// isAlreadyExists reports whether a Cloud SQL API error indicates the resource
+// already exists (HTTP 409), so callers can treat create as idempotent.
+func isAlreadyExists(err error) bool {
+	var gerr *googleapi.Error
+	return errors.As(err, &gerr) && gerr.Code == http.StatusConflict
+}
+
+// isNotFound reports whether a Cloud SQL API error indicates the resource does
+// not exist (HTTP 404), so callers can treat delete as idempotent.
+func isNotFound(err error) bool {
+	var gerr *googleapi.Error
+	return errors.As(err, &gerr) && gerr.Code == http.StatusNotFound
+}
+
+// waitForOperation polls a Cloud SQL long-running operation until it reaches
+// DONE (or the operation/context deadline is hit). Cloud SQL Insert/Delete calls
+// return immediately with an in-flight operation; without awaiting it, dependent
+// steps race the operation (e.g. a user drop firing before its database drop
+// completes, or a pod connecting before the database exists).
+func (m *Manager) waitForOperation(ctx context.Context, op *admin.Operation) error {
+	if op == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, operationWaitTimeout)
+	defer cancel()
+
+	for {
+		if op.Status == "DONE" {
+			if op.Error != nil && len(op.Error.Errors) > 0 {
+				return fmt.Errorf("cloud sql operation %s failed: %s", op.Name, op.Error.Errors[0].Message)
+			}
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for cloud sql operation %s: %w", op.Name, ctx.Err())
+		case <-time.After(operationPollInterval):
+		}
+
+		refreshed, err := m.operationsClient.Get(m.config.Google.ProjectID, op.Name).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("failed to poll cloud sql operation %s: %w", op.Name, err)
+		}
+		op = refreshed
+	}
+}
+
+// CreateDatabase creates a new Cloud SQL database. It is idempotent: an existing
+// database is treated as success, and the create operation is awaited to
+// completion so callers can rely on the database actually existing on return.
 func (m *Manager) CreateDatabase(ctx context.Context, name string) error {
 	database := &admin.Database{
 		Name: name,
 	}
 
-	_, err := m.databasesClient.Insert(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID, database).Context(ctx).Do()
+	op, err := m.databasesClient.Insert(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID, database).Context(ctx).Do()
 	if err != nil {
+		if isAlreadyExists(err) {
+			m.logger.WithContext(ctx).WithField("database", name).Info("Cloud SQL database already exists, treating as created")
+			return nil
+		}
 		m.logger.WithContext(ctx).WithError(err).WithField("database", name).Error("Failed to create database")
+		return fmt.Errorf("failed to create database: %w", err)
+	}
+
+	if err := m.waitForOperation(ctx, op); err != nil {
 		return fmt.Errorf("failed to create database: %w", err)
 	}
 
@@ -68,7 +147,8 @@ func (m *Manager) CreateDatabase(ctx context.Context, name string) error {
 	return nil
 }
 
-// CreateDatabaseUser creates a new Cloud SQL user with a random password
+// CreateDatabaseUser creates a new Cloud SQL user with a random password and
+// awaits the create operation.
 func (m *Manager) CreateDatabaseUser(ctx context.Context, name string) (string, error) {
 	password, err := generatePassword(16)
 	if err != nil {
@@ -80,9 +160,13 @@ func (m *Manager) CreateDatabaseUser(ctx context.Context, name string) (string, 
 		Password: password,
 	}
 
-	_, err = m.usersClient.Insert(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID, user).Context(ctx).Do()
+	op, err := m.usersClient.Insert(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID, user).Context(ctx).Do()
 	if err != nil {
 		m.logger.WithContext(ctx).WithError(err).WithField("user", name).Error("Failed to create database user")
+		return "", fmt.Errorf("failed to create database user: %w", err)
+	}
+
+	if err := m.waitForOperation(ctx, op); err != nil {
 		return "", fmt.Errorf("failed to create database user: %w", err)
 	}
 
@@ -94,8 +178,18 @@ func (m *Manager) CreateDatabaseUser(ctx context.Context, name string) (string, 
 	return password, nil
 }
 
-// CreateSecret creates a Kubernetes secret with database credentials
+// CreateSecret creates (or updates) a Kubernetes secret with database
+// credentials. It is idempotent so that a retry after a partial provisioning
+// failure converges the secret to the current password instead of failing with
+// AlreadyExists.
 func (m *Manager) CreateSecret(ctx context.Context, databaseName, password string) error {
+	data := map[string][]byte{
+		"POSTGRES_USER":     []byte(databaseName),
+		"POSTGRES_PASSWORD": []byte(password),
+		"POSTGRES_DB":       []byte(databaseName),
+		"POSTGRES_HOST":     []byte(m.config.Unleash.SQLInstanceAddress),
+	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      databaseName,
@@ -105,15 +199,22 @@ func (m *Manager) CreateSecret(ctx context.Context, databaseName, password strin
 			Kind:       "Secret",
 			APIVersion: "v1",
 		},
-		Data: map[string][]byte{
-			"POSTGRES_USER":     []byte(databaseName),
-			"POSTGRES_PASSWORD": []byte(password),
-			"POSTGRES_DB":       []byte(databaseName),
-			"POSTGRES_HOST":     []byte(m.config.Unleash.SQLInstanceAddress),
-		},
+		Data: data,
 	}
 
 	if err := m.kubeClient.Create(ctx, secret); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			existing := &corev1.Secret{}
+			if getErr := m.kubeClient.Get(ctx, ctrl.ObjectKeyFromObject(secret), existing); getErr != nil {
+				return fmt.Errorf("failed to get existing database secret: %w", getErr)
+			}
+			existing.Data = data
+			if updateErr := m.kubeClient.Update(ctx, existing); updateErr != nil {
+				return fmt.Errorf("failed to update database secret: %w", updateErr)
+			}
+			m.logger.WithContext(ctx).WithField("database", databaseName).Info("Updated existing database credentials secret")
+			return nil
+		}
 		m.logger.WithContext(ctx).WithError(err).WithField("database", databaseName).Error("Failed to create database secret")
 		return fmt.Errorf("failed to create database secret: %w", err)
 	}
@@ -126,11 +227,21 @@ func (m *Manager) CreateSecret(ctx context.Context, databaseName, password strin
 	return nil
 }
 
-// DeleteDatabase deletes a Cloud SQL database
+// DeleteDatabase deletes a Cloud SQL database. It is idempotent (a missing
+// database is treated as success) and awaits the delete operation so a
+// subsequent user delete does not race the still-running database drop.
 func (m *Manager) DeleteDatabase(ctx context.Context, name string) error {
-	_, err := m.databasesClient.Delete(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID, name).Context(ctx).Do()
+	op, err := m.databasesClient.Delete(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID, name).Context(ctx).Do()
 	if err != nil {
+		if isNotFound(err) {
+			m.logger.WithContext(ctx).WithField("database", name).Info("Cloud SQL database already absent, nothing to delete")
+			return nil
+		}
 		m.logger.WithContext(ctx).WithError(err).WithField("database", name).Error("Failed to delete database")
+		return fmt.Errorf("failed to delete database: %w", err)
+	}
+
+	if err := m.waitForOperation(ctx, op); err != nil {
 		return fmt.Errorf("failed to delete database: %w", err)
 	}
 
@@ -142,11 +253,20 @@ func (m *Manager) DeleteDatabase(ctx context.Context, name string) error {
 	return nil
 }
 
-// DeleteDatabaseUser deletes a Cloud SQL user
+// DeleteDatabaseUser deletes a Cloud SQL user. It is idempotent and awaits the
+// delete operation.
 func (m *Manager) DeleteDatabaseUser(ctx context.Context, name string) error {
-	_, err := m.usersClient.Delete(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID).Name(name).Context(ctx).Do()
+	op, err := m.usersClient.Delete(m.config.Google.ProjectID, m.config.Unleash.SQLInstanceID).Name(name).Context(ctx).Do()
 	if err != nil {
+		if isNotFound(err) {
+			m.logger.WithContext(ctx).WithField("user", name).Info("Cloud SQL user already absent, nothing to delete")
+			return nil
+		}
 		m.logger.WithContext(ctx).WithError(err).WithField("user", name).Error("Failed to delete database user")
+		return fmt.Errorf("failed to delete database user: %w", err)
+	}
+
+	if err := m.waitForOperation(ctx, op); err != nil {
 		return fmt.Errorf("failed to delete database user: %w", err)
 	}
 
@@ -158,7 +278,8 @@ func (m *Manager) DeleteDatabaseUser(ctx context.Context, name string) error {
 	return nil
 }
 
-// DeleteSecret deletes a Kubernetes secret
+// DeleteSecret deletes a Kubernetes secret. A missing secret is treated as
+// success so delete/cleanup is idempotent.
 func (m *Manager) DeleteSecret(ctx context.Context, name string) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -172,6 +293,9 @@ func (m *Manager) DeleteSecret(ctx context.Context, name string) error {
 	}
 
 	if err := m.kubeClient.Delete(ctx, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		m.logger.WithContext(ctx).WithError(err).WithField("secret", name).Error("Failed to delete database secret")
 		return fmt.Errorf("failed to delete database secret: %w", err)
 	}

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -53,11 +53,13 @@ func apiKeyAuthMiddleware(keys []string, enforced bool, logger *logrus.Logger, s
 		}
 
 		if validAPIKey(extractAPIKey(c), keys) {
+			apiAuthRequestsTotal.WithLabelValues(authOutcomeAuthenticated).Inc()
 			c.Next()
 			return
 		}
 
 		if enforced {
+			apiAuthRequestsTotal.WithLabelValues(authOutcomeRejected).Inc()
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error":       "unauthorized",
 				"message":     "missing or invalid API key",
@@ -66,6 +68,10 @@ func apiKeyAuthMiddleware(keys []string, enforced bool, logger *logrus.Logger, s
 			return
 		}
 
+		// Dark-launch / accept mode: allow but record so the rollout is
+		// measurable. When bifrost_api_auth_requests_total{outcome="unauthenticated_allowed"}
+		// reaches zero, it is safe to flip BIFROST_AUTH_ENFORCED to true.
+		apiAuthRequestsTotal.WithLabelValues(authOutcomeUnauthenticated).Inc()
 		logger.WithFields(logrus.Fields{
 			"event":     "unauthenticated_request",
 			"path":      c.Request.URL.Path,

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// extractAPIKey returns the pre-shared key presented on the request, accepting
+// either "Authorization: Bearer <key>" (or a bare "Authorization: <key>") or an
+// "X-API-Key: <key>" header.
+func extractAPIKey(c *gin.Context) string {
+	if h := c.GetHeader("Authorization"); h != "" {
+		if len(h) >= 7 && strings.EqualFold(h[:7], "Bearer ") {
+			return strings.TrimSpace(h[7:])
+		}
+		return strings.TrimSpace(h)
+	}
+	return strings.TrimSpace(c.GetHeader("X-API-Key"))
+}
+
+// validAPIKey reports whether provided matches any configured key, using a
+// constant-time comparison against every key (no early return) so neither the
+// match result nor which key matched is leaked by timing.
+func validAPIKey(provided string, keys []string) bool {
+	providedBytes := []byte(provided)
+	var match int
+	for _, k := range keys {
+		match |= subtle.ConstantTimeCompare(providedBytes, []byte(k))
+	}
+	return match == 1
+}
+
+// apiKeyAuthMiddleware authenticates requests with a pre-shared key.
+//
+// Requests to skipPaths (health, openapi) are always allowed. When no valid key
+// is presented: if enforced, the request is rejected with 401; otherwise
+// ("accept-then-enforce") it is allowed but logged so unauthenticated callers
+// are visible before enforcement is switched on.
+func apiKeyAuthMiddleware(keys []string, enforced bool, logger *logrus.Logger, skipPaths []string) gin.HandlerFunc {
+	skip := make(map[string]struct{}, len(skipPaths))
+	for _, p := range skipPaths {
+		skip[p] = struct{}{}
+	}
+
+	return func(c *gin.Context) {
+		if _, ok := skip[c.Request.URL.Path]; ok {
+			c.Next()
+			return
+		}
+
+		if validAPIKey(extractAPIKey(c), keys) {
+			c.Next()
+			return
+		}
+
+		if enforced {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error":       "unauthorized",
+				"message":     "missing or invalid API key",
+				"status_code": http.StatusUnauthorized,
+			})
+			return
+		}
+
+		logger.WithFields(logrus.Fields{
+			"event":     "unauthenticated_request",
+			"path":      c.Request.URL.Path,
+			"method":    c.Request.Method,
+			"client_ip": c.ClientIP(),
+		}).Warn("Request without a valid API key allowed (authentication not enforced)")
+		c.Next()
+	}
+}

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -6,8 +6,50 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 )
+
+// TestAPIKeyAuthMiddleware_RecordsOutcome verifies the dark-launch signal: every
+// non-exempt request increments bifrost_api_auth_requests_total with the outcome
+// operators watch to decide when it's safe to enforce.
+func TestAPIKeyAuthMiddleware_RecordsOutcome(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(nopWriter{})
+
+	do := func(enforced bool, header string) {
+		r := gin.New()
+		r.Use(apiKeyAuthMiddleware([]string{"k"}, enforced, logger, nil))
+		r.GET("/v1/x", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/x", nil)
+		if header != "" {
+			req.Header.Set("Authorization", header)
+		}
+		r.ServeHTTP(w, req)
+	}
+
+	cases := []struct {
+		name     string
+		enforced bool
+		header   string
+		outcome  string
+	}{
+		{"authenticated", true, "Bearer k", authOutcomeAuthenticated},
+		{"rejected", true, "", authOutcomeRejected},
+		{"accept-mode", false, "", authOutcomeUnauthenticated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := testutil.ToFloat64(apiAuthRequestsTotal.WithLabelValues(tc.outcome))
+			do(tc.enforced, tc.header)
+			if got := testutil.ToFloat64(apiAuthRequestsTotal.WithLabelValues(tc.outcome)); got != before+1 {
+				t.Errorf("outcome %q counter = %v, want %v", tc.outcome, got, before+1)
+			}
+		})
+	}
+}
 
 func TestValidAPIKey(t *testing.T) {
 	keys := []string{"key-one", "key-two"}

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+func TestValidAPIKey(t *testing.T) {
+	keys := []string{"key-one", "key-two"}
+	cases := []struct {
+		name     string
+		provided string
+		want     bool
+	}{
+		{"matches first", "key-one", true},
+		{"matches second (rotation)", "key-two", true},
+		{"no match", "nope", false},
+		{"empty provided", "", false},
+		{"prefix is not enough", "key-on", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := validAPIKey(tc.provided, keys); got != tc.want {
+				t.Fatalf("validAPIKey(%q) = %v, want %v", tc.provided, got, tc.want)
+			}
+		})
+	}
+
+	if validAPIKey("anything", nil) {
+		t.Fatal("no configured keys must never validate")
+	}
+}
+
+func TestExtractAPIKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{"bearer", map[string]string{"Authorization": "Bearer secret"}, "secret"},
+		{"bearer case-insensitive", map[string]string{"Authorization": "bearer secret"}, "secret"},
+		{"bare authorization", map[string]string{"Authorization": "secret"}, "secret"},
+		{"x-api-key", map[string]string{"X-API-Key": "secret"}, "secret"},
+		{"authorization wins over x-api-key", map[string]string{"Authorization": "Bearer a", "X-API-Key": "b"}, "a"},
+		{"none", map[string]string{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodGet, "/v1/unleash", nil)
+			for k, v := range tc.headers {
+				c.Request.Header.Set(k, v)
+			}
+			if got := extractAPIKey(c); got != tc.want {
+				t.Fatalf("extractAPIKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAPIKeyAuthMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := logrus.New()
+	logger.SetOutput(nopWriter{})
+
+	newRouter := func(keys []string, enforced bool) *gin.Engine {
+		r := gin.New()
+		r.Use(apiKeyAuthMiddleware(keys, enforced, logger, []string{"/healthz"}))
+		r.GET("/healthz", func(c *gin.Context) { c.String(http.StatusOK, "OK") })
+		r.GET("/v1/unleash", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		return r
+	}
+
+	cases := []struct {
+		name     string
+		keys     []string
+		enforced bool
+		path     string
+		header   string
+		wantCode int
+	}{
+		{"skip path always allowed", []string{"k"}, true, "/healthz", "", http.StatusOK},
+		{"enforced + valid key", []string{"k"}, true, "/v1/unleash", "Bearer k", http.StatusOK},
+		{"enforced + missing key", []string{"k"}, true, "/v1/unleash", "", http.StatusUnauthorized},
+		{"enforced + wrong key", []string{"k"}, true, "/v1/unleash", "Bearer x", http.StatusUnauthorized},
+		{"not enforced + missing key allowed", []string{"k"}, false, "/v1/unleash", "", http.StatusOK},
+		{"not enforced + valid key allowed", []string{"k"}, false, "/v1/unleash", "Bearer k", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			newRouter(tc.keys, tc.enforced).ServeHTTP(w, req)
+			if w.Code != tc.wantCode {
+				t.Fatalf("%s: got %d, want %d", tc.name, w.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -1,0 +1,25 @@
+package server
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Authentication outcomes recorded on every non-exempt API request. They exist
+// so the PSK auth rollout can be dark-launched: while enforcement is off, watch
+// authOutcomeUnauthenticated fall to zero (all callers sending a valid key)
+// before flipping BIFROST_AUTH_ENFORCED to true.
+const (
+	authOutcomeAuthenticated   = "authenticated"
+	authOutcomeUnauthenticated = "unauthenticated_allowed" // no valid key, allowed (accept mode)
+	authOutcomeRejected        = "rejected"                // no valid key, rejected (enforce mode)
+)
+
+var apiAuthRequestsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "bifrost_api_auth_requests_total",
+		Help: "Total API requests by authentication outcome (drives the PSK auth dark launch).",
+	},
+	[]string{"outcome"},
+)
+
+func init() {
+	prometheus.MustRegister(apiAuthRequestsTotal)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -30,13 +30,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func initGoogleClients(ctx context.Context) (*admin.InstancesService, *admin.DatabasesService, *admin.UsersService, error) {
+func initGoogleClients(ctx context.Context) (*admin.InstancesService, *admin.DatabasesService, *admin.UsersService, *admin.OperationsService, error) {
 	googleClient, err := admin.NewService(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return googleClient.Instances, googleClient.Databases, googleClient.Users, nil
+	return googleClient.Instances, googleClient.Databases, googleClient.Users, googleClient.Operations, nil
 }
 
 func initKubernetesClient() (ctrl.Client, error) {
@@ -170,8 +170,16 @@ func setupRouter(config *config.Config, logger *logrus.Logger, v1Service *unleas
 	// Create OpenAPI handler
 	openAPIHandler := v1.NewOpenAPIHandler(v1Service, config, logger, releaseChannelRepo)
 
-	// Register API routes (paths already include /v1 prefix)
+	// Register API routes (paths already include /v1 prefix).
+	// The auth and apiVersion middleware are attached here so they apply to the
+	// API routes but not to the health/openapi endpoints registered above.
 	router.Use(apiVersionMiddleware("v1"))
+	router.Use(apiKeyAuthMiddleware(
+		config.Server.Auth.ParsedAPIKeys(),
+		config.Server.Auth.Enforced,
+		logger,
+		[]string{"/healthz", "/openapi.json"},
+	))
 	generated.RegisterHandlers(router, openAPIHandler)
 
 	return router
@@ -198,18 +206,29 @@ func validateDefaultReleaseChannel(ctx context.Context, config *config.Config, r
 func Run(config *config.Config) {
 	logger := initLogger()
 
+	// Fail closed on a misconfiguration where auth is enforced but no keys are
+	// set — otherwise every request would be rejected.
+	if config.Server.Auth.Enforced && len(config.Server.Auth.ParsedAPIKeys()) == 0 {
+		logger.Fatal("BIFROST_AUTH_ENFORCED is true but no API keys are configured (set BIFROST_API_KEYS)")
+	}
+	if len(config.Server.Auth.ParsedAPIKeys()) == 0 {
+		logger.Warn("No API keys configured (BIFROST_API_KEYS); API authentication is effectively disabled")
+	} else if !config.Server.Auth.Enforced {
+		logger.Warn("API keys configured but BIFROST_AUTH_ENFORCED is false; running in accept-then-enforce mode")
+	}
+
 	kubeClient, err := initKubernetesClient()
 	if err != nil {
 		logger.Fatal(err)
 	}
 
-	_, sqlDatabasesClient, sqlUsersClient, err := initGoogleClients(context.Background())
+	_, sqlDatabasesClient, sqlUsersClient, sqlOperationsClient, err := initGoogleClients(context.Background())
 	if err != nil {
 		logger.Fatal(err)
 	}
 
 	// Create v1 service
-	dbManager := cloudsql.NewManager(sqlDatabasesClient, sqlUsersClient, kubeClient, config, logger)
+	dbManager := cloudsql.NewManager(sqlDatabasesClient, sqlUsersClient, sqlOperationsClient, kubeClient, config, logger)
 	repo := kubernetes.NewUnleashRepository(kubeClient, config, logger)
 	unleashService := unleashapp.NewService(repo, dbManager, config, logger)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nais/bifrost/pkg/infrastructure/kubernetes"
 	fqdnV1alpha3 "github.com/nais/fqdn-policy/api/v1alpha3"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	admin "google.golang.org/api/sqladmin/v1beta4"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -149,12 +150,17 @@ func jsonLoggerMiddleware(logger *logrus.Logger, skipPaths []string) gin.Handler
 func setupRouter(config *config.Config, logger *logrus.Logger, v1Service *unleashapp.Service, releaseChannelRepo releasechannel.Repository) *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Recovery())
-	router.Use(jsonLoggerMiddleware(logger, []string{"/healthz"}))
+	router.Use(jsonLoggerMiddleware(logger, []string{"/healthz", "/metrics"}))
 
 	// Health check
 	router.GET("/healthz", func(c *gin.Context) {
 		c.String(200, "OK")
 	})
+
+	// Prometheus metrics. Registered before the auth middleware below so it is
+	// scrapeable without a key. Drives the dark-launch dashboards
+	// (bifrost_api_auth_requests_total{outcome=...}).
+	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	// Serve OpenAPI specification (JSON format from embedded spec)
 	router.GET("/openapi.json", func(c *gin.Context) {


### PR DESCRIPTION
## Summary

Two urgent Phase-0 hardening changes from the bifrost adversarial review
(`docs/RECONCILER_IMPROVEMENT_PLAN.md`, epic #543).

Refs #545 (provisioning correctness) and #544 (pre-shared-key auth). Both issues
are broader than this PR (they include cross-repo work — see **External systems**
below), so this PR does not close them.

## Provisioning correctness — stop orphaning resources (#545)

Provisioning spans Cloud SQL (database + user) and Kubernetes (secret + CRD) with
no cross-system transaction, so partial failures leaked resources.

- **`Service.Create` rolls back** everything it created if a later step fails, on
  a detached, bounded context — a failed create no longer orphans a Cloud SQL
  database, user, secret, or CRD.
- **`Service.Delete` is best-effort and idempotent**: every teardown step runs
  regardless of earlier failures (errors aggregated), and each underlying
  operation treats an already-absent resource as success. `DeleteInstance` now
  also reaps orphans even when the CRD is already gone, while preserving the 404
  contract for a genuinely-absent instance.
- **Cloud SQL operations are awaited** (new `OperationsService` +
  `waitForOperation`), so dependent steps no longer race the in-flight operation
  (a pod connecting before the DB exists; a user drop racing the database drop).
  Manager create/delete ops are now idempotent (`AlreadyExists`/`NotFound`
  tolerated); `CreateSecret` is create-or-update.

> Note: awaiting operations makes `Create` block until the DB is actually ready
> (bounded to 5 min). Combined with rollback, create is now **either fully
> provisioned or fully cleaned up** — never fast-return-with-orphan. If the
> caller's timeout is short, create returns an error *and rolls back cleanly*.
> The async home for this is the reconciler (#546); this is the correct interim.

## Pre-shared-key authentication (#544)

Bifrost has no authentication today; it is called only by nais-api (which
authenticates end users and enforces team ownership). So auth is a **pre-shared
key**, held in fasit and injected into both services.

- `apiKeyAuthMiddleware` on `/v1/*` (health + openapi exempt), **constant-time**
  comparison, **multiple keys** for zero-downtime rotation, from `BIFROST_API_KEYS`.
- **Accept-then-enforce**: `BIFROST_AUTH_ENFORCED` defaults `false` — the first
  rollout logs unauthenticated calls without blocking, so nais-api can start
  sending the key before enforcement; a later rollout flips it to `true` to fail
  closed. Startup fails closed if enforced with no keys configured.

## ⚠️ External systems — required for this to work

This PR is the **bifrost side only**. The following must be done in other repos,
**in order**, for PSK auth to take effect safely (nothing here breaks existing
traffic until step 4):

1. **`nais-terraform-modules`** (`modules/management/bifrost.tf`): add a
   `bifrost_api_key` fasit value (mirror the existing `bifrost_teams_api_key`),
   and expose it to **both** the bifrost and nais-api deployments.
2. **bifrost Helm chart** (`charts/bifrost`): wire the new env vars into the
   deployment and `Feature.yaml`:
   - `BIFROST_API_KEYS` ← the fasit `bifrost_api_key` (comma-separated supports rotation)
   - `BIFROST_AUTH_ENFORCED` ← `false` initially (a fasit-toggleable bool)
   Deploy bifrost with keys configured but **enforcement off** (accept mode);
   confirm via the `unauthenticated_request` warn logs that traffic is seen.
3. **`nais/api`**: add a `bifrostclient` `RequestEditorFn` that sets
   `Authorization: Bearer <key>` (or `X-API-Key`) from its fasit-injected config
   on every request (`internal/unleash/bifrost.go` / `internal/cmd/api/api.go`).
   Deploy nais-api **before** enabling enforcement.
4. **Flip enforcement**: once the `unauthenticated_request` logs are zero, set
   `BIFROST_AUTH_ENFORCED=true` and redeploy bifrost. Now unauthenticated calls
   are rejected with 401.

Rotation later: add the new key to `BIFROST_API_KEYS` (both accepted), roll
nais-api to the new key, then drop the old key.

### New/changed configuration (bifrost)

| Env var | Default | Purpose |
| --- | --- | --- |
| `BIFROST_API_KEYS` | _(empty)_ | Comma-separated accepted pre-shared keys (rotation). Empty = auth effectively disabled. |
| `BIFROST_AUTH_ENFORCED` | `false` | When true, reject requests without a valid key. |

## Testing

- `go build ./...`, `go vet ./...` clean; full suite (146 tests) passes.
- New unit tests: auth middleware (enforced/not, valid/invalid/missing key, skip
  paths, Bearer vs X-API-Key) and constant-time matcher; create-rollback (CRD and
  secret failure), no-rollback-on-success, best-effort-continue-on-delete.

## Out of scope (tracked in the epic #543)

The reconciler itself (#546), migration folding (#547), and the remaining ops
hardening (#548) — plus in-bifrost input validation and secret-redaction in
responses — are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
