### PR TITLE
Add controller-runtime reconciler foundation for Unleash instances

### DIFF
--- a/charts/bifrost/Feature.yaml
+++ b/charts/bifrost/Feature.yaml
@@ -18,6 +18,16 @@ values:
     config:
       type: string
 
+  # Reconciler dark-launch toggles (off -> enabled+dryRun -> enabled).
+  backend.reconciler.enabled:
+    displayName: Enable the Unleash reconcile loop
+    config:
+      type: bool
+  backend.reconciler.dryRun:
+    displayName: Reconciler dry-run (observe only, no writes)
+    config:
+      type: bool
+
   backend.unleash.apiIngressClass:
     displayName: Api Ingress Class
     computed:

--- a/charts/bifrost/templates/backend-deployment.yaml
+++ b/charts/bifrost/templates/backend-deployment.yaml
@@ -103,6 +103,14 @@ spec:
             - name: BIFROST_UNLEASH_CHANNEL_MIGRATION_DELAY
               value: {{ .Values.backend.unleash.channelMigration.delay | quote }}
             {{- end }}
+
+            # Reconciler (dark-launch via dry-run; see docs/RECONCILER_IMPROVEMENT_PLAN.md §6a).
+            - name: BIFROST_RECONCILER_ENABLED
+              value: {{ .Values.backend.reconciler.enabled | quote }}
+            - name: BIFROST_RECONCILER_DRY_RUN
+              value: {{ .Values.backend.reconciler.dryRun | quote }}
+            - name: BIFROST_RECONCILER_RESYNC_INTERVAL
+              value: {{ .Values.backend.reconciler.resyncInterval | quote }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -11,6 +11,14 @@ backend:
   logLevel: info
   logFormat: json
 
+  # Reconcile loop that converges managed Unleash instances to their desired
+  # config. Dark-launched: enable with dryRun=true first, watch
+  # bifrost_reconciler_actions_total{action="would_change"}, then set dryRun=false.
+  reconciler:
+    enabled: false
+    dryRun: false
+    resyncInterval: "10m"
+
   unleash:
     # Kubernetes namespace to create unleash instances in
     # instanceNamespace:  # mapped in fasit

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/oasdiff/yaml v0.1.0 // indirect
@@ -107,7 +108,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -128,11 +128,29 @@ func (c *UnleashConfig) ParseChannelMigrationMap() (map[string]string, error) {
 	return result, nil
 }
 
+// ReconcilerConfig configures the controller-runtime reconcile loop that keeps
+// bifrost-managed Unleash instances converged to their desired configuration.
+type ReconcilerConfig struct {
+	// Enabled turns on the reconcile loop. Default off so it can be rolled out
+	// per environment behind a feature flag.
+	Enabled bool `env:"BIFROST_RECONCILER_ENABLED,default=false"`
+	// ResyncInterval is how often every managed instance is re-rendered even
+	// without a CR event, so global-config changes propagate and drift heals.
+	ResyncInterval time.Duration `env:"BIFROST_RECONCILER_RESYNC_INTERVAL,default=10m"`
+	// LeaderElection ensures at most one replica reconciles. Requires lease RBAC;
+	// keep off while running a single replica.
+	LeaderElection bool `env:"BIFROST_RECONCILER_LEADER_ELECTION,default=false"`
+	// LeaderElectionNamespace is where the lease lives; empty auto-detects the
+	// pod namespace in-cluster.
+	LeaderElectionNamespace string `env:"BIFROST_RECONCILER_LEADER_ELECTION_NAMESPACE"`
+}
+
 type Config struct {
 	Meta                MetaConfig
 	Server              ServerConfig
 	Google              GoogleConfig
 	Unleash             UnleashConfig
+	Reconciler          ReconcilerConfig
 	DebugMode           bool
 	CloudConnectorProxy string `env:"BIFROST_CLOUD_CONNECTOR_PROXY_IMAGE,default=gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,11 @@ type ReconcilerConfig struct {
 	// Enabled turns on the reconcile loop. Default off so it can be rolled out
 	// per environment behind a feature flag.
 	Enabled bool `env:"BIFROST_RECONCILER_ENABLED,default=false"`
+	// DryRun runs the loop in observe mode: it computes and records (via the
+	// bifrost_reconciler_actions_total{action="would_change"} metric) what it
+	// would change but never writes. This is the dark-launch step — enable the
+	// reconciler with DryRun on, confirm the blast radius, then set it false.
+	DryRun bool `env:"BIFROST_RECONCILER_DRY_RUN,default=false"`
 	// ResyncInterval is how often every managed instance is re-rendered even
 	// without a CR event, so global-config changes propagate and drift heals.
 	ResyncInterval time.Duration `env:"BIFROST_RECONCILER_RESYNC_INTERVAL,default=10m"`

--- a/pkg/infrastructure/kubernetes/managed.go
+++ b/pkg/infrastructure/kubernetes/managed.go
@@ -1,0 +1,66 @@
+package kubernetes
+
+import (
+	"encoding/json"
+
+	"github.com/nais/bifrost/pkg/domain/unleash"
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+)
+
+const (
+	// LabelManagedBy marks which controller owns an Unleash instance. Bifrost
+	// only reconciles instances it manages, identified by this label, so the
+	// reconciler never touches hand-authored or foreign Unleash CRs.
+	LabelManagedBy   = "app.kubernetes.io/managed-by"
+	ManagedByBifrost = "bifrost"
+
+	// AnnotationDesiredState carries the bifrost per-instance intent (the
+	// unleash.Config) as JSON. It is the authoritative, non-lossy source of
+	// truth the reconciler re-renders from — unlike reverse-engineering the
+	// rendered spec via LoadConfigFromCRD, which drops fields.
+	AnnotationDesiredState = "bifrost.nais.io/desired-state"
+)
+
+// MarshalIntent serializes a per-instance config for storage in the
+// desired-state annotation.
+func MarshalIntent(cfg *unleash.Config) (string, error) {
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// UnmarshalIntent parses the desired-state annotation back into a config.
+func UnmarshalIntent(s string) (*unleash.Config, error) {
+	cfg := &unleash.Config{}
+	if err := json.Unmarshal([]byte(s), cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// IsManagedByBifrost reports whether the reconciler owns this instance.
+func IsManagedByBifrost(crd *unleashv1.Unleash) bool {
+	return crd.GetLabels()[LabelManagedBy] == ManagedByBifrost
+}
+
+// stampManagedMetadata sets the managed-by label and desired-state annotation on
+// a rendered CRD so every create/update marks the instance as bifrost-managed
+// and records the intent it was rendered from.
+func stampManagedMetadata(server *unleashv1.Unleash, cfg *unleash.Config) {
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	server.Labels[LabelManagedBy] = ManagedByBifrost
+
+	// Best-effort: if the intent cannot be marshaled, the reconciler falls back
+	// to LoadConfigFromCRD, so we simply omit the annotation rather than fail
+	// rendering.
+	if intent, err := MarshalIntent(cfg); err == nil {
+		if server.Annotations == nil {
+			server.Annotations = map[string]string{}
+		}
+		server.Annotations[AnnotationDesiredState] = intent
+	}
+}

--- a/pkg/infrastructure/kubernetes/unleash_repository.go
+++ b/pkg/infrastructure/kubernetes/unleash_repository.go
@@ -754,6 +754,10 @@ func BuildUnleashCRD(c *config.Config, cfg *unleash.Config) unleashv1.Unleash {
 		server.Spec.ReleaseChannel.Name = cfg.ReleaseChannelName
 	}
 
+	// Mark the instance as bifrost-managed and record the intent it was rendered
+	// from, so the reconciler can find and re-render it non-lossily.
+	stampManagedMetadata(&server, cfg)
+
 	return server
 }
 

--- a/pkg/reconciler/manager.go
+++ b/pkg/reconciler/manager.go
@@ -1,0 +1,55 @@
+package reconciler
+
+import (
+	"fmt"
+
+	"github.com/nais/bifrost/pkg/config"
+	fqdnV1alpha3 "github.com/nais/fqdn-policy/api/v1alpha3"
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	client_go_scheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// NewManager builds a controller-runtime manager hosting the Unleash reconciler.
+// The metrics server is disabled to avoid colliding with bifrost's HTTP server
+// port; leader election is opt-in so the manager is safe to run in every replica
+// once leases + RBAC are configured.
+func NewManager(cfg *config.Config, logger *logrus.Logger) (manager.Manager, error) {
+	scheme := runtime.NewScheme()
+	if err := client_go_scheme.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add client-go scheme: %w", err)
+	}
+	if err := unleashv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add unleash scheme: %w", err)
+	}
+	if err := fqdnV1alpha3.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add fqdn scheme: %w", err)
+	}
+
+	restCfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("get kube config: %w", err)
+	}
+
+	mgr, err := ctrl.NewManager(restCfg, manager.Options{
+		Scheme:                  scheme,
+		Metrics:                 metricsserver.Options{BindAddress: "0"},
+		LeaderElection:          cfg.Reconciler.LeaderElection,
+		LeaderElectionID:        "bifrost-reconciler.nais.io",
+		LeaderElectionNamespace: cfg.Reconciler.LeaderElectionNamespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create manager: %w", err)
+	}
+
+	r := NewUnleashReconciler(mgr.GetClient(), cfg, logger, cfg.Reconciler.ResyncInterval)
+	if err := r.SetupWithManager(mgr); err != nil {
+		return nil, fmt.Errorf("set up reconciler: %w", err)
+	}
+
+	return mgr, nil
+}

--- a/pkg/reconciler/manager.go
+++ b/pkg/reconciler/manager.go
@@ -46,7 +46,7 @@ func NewManager(cfg *config.Config, logger *logrus.Logger) (manager.Manager, err
 		return nil, fmt.Errorf("create manager: %w", err)
 	}
 
-	r := NewUnleashReconciler(mgr.GetClient(), cfg, logger, cfg.Reconciler.ResyncInterval)
+	r := NewUnleashReconciler(mgr.GetClient(), cfg, logger, cfg.Reconciler.ResyncInterval, cfg.Reconciler.DryRun)
 	if err := r.SetupWithManager(mgr); err != nil {
 		return nil, fmt.Errorf("set up reconciler: %w", err)
 	}

--- a/pkg/reconciler/metrics.go
+++ b/pkg/reconciler/metrics.go
@@ -1,0 +1,25 @@
+package reconciler
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Reconcile actions recorded per instance per reconcile. They exist to
+// dark-launch the reconciler: enable it with dry-run on and watch
+// action="would_change" to understand the blast radius before letting it write.
+const (
+	actionInSync      = "in_sync"      // already matches desired; no action
+	actionWouldChange = "would_change" // dry-run: a change is needed but was not applied
+	actionChanged     = "changed"      // a converging patch was applied
+	actionError       = "error"        // the patch failed
+)
+
+var reconcilerActionsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "bifrost_reconciler_actions_total",
+		Help: "Reconcile actions by outcome (drives the reconciler dark launch).",
+	},
+	[]string{"action"},
+)
+
+func init() {
+	prometheus.MustRegister(reconcilerActionsTotal)
+}

--- a/pkg/reconciler/unleash.go
+++ b/pkg/reconciler/unleash.go
@@ -32,15 +32,17 @@ type UnleashReconciler struct {
 	config *config.Config
 	logger *logrus.Logger
 	resync time.Duration
+	dryRun bool
 }
 
 // NewUnleashReconciler creates a reconciler. A non-positive resync falls back to
-// the default interval.
-func NewUnleashReconciler(c client.Client, cfg *config.Config, logger *logrus.Logger, resync time.Duration) *UnleashReconciler {
+// the default interval. When dryRun is true the reconciler runs in observe mode:
+// it computes and records what it would change but never writes.
+func NewUnleashReconciler(c client.Client, cfg *config.Config, logger *logrus.Logger, resync time.Duration, dryRun bool) *UnleashReconciler {
 	if resync <= 0 {
 		resync = defaultResyncInterval
 	}
-	return &UnleashReconciler{client: c, config: cfg, logger: logger, resync: resync}
+	return &UnleashReconciler{client: c, config: cfg, logger: logger, resync: resync, dryRun: dryRun}
 }
 
 // Reconcile renders the desired spec from the instance's intent and patches the
@@ -80,6 +82,15 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	desired := kubernetes.BuildUnleashCRD(r.config, cfg)
 
 	if r.inSync(crd, &desired) {
+		reconcilerActionsTotal.WithLabelValues(actionInSync).Inc()
+		return ctrl.Result{RequeueAfter: r.resync}, nil
+	}
+
+	// Observe mode (dark launch): record that a change is needed but do not write,
+	// so the blast radius can be measured before the reconciler is allowed to act.
+	if r.dryRun {
+		reconcilerActionsTotal.WithLabelValues(actionWouldChange).Inc()
+		log.Info("Instance differs from desired configuration (dry-run: no changes applied)")
 		return ctrl.Result{RequeueAfter: r.resync}, nil
 	}
 
@@ -90,10 +101,12 @@ func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	applyManagedMetadata(crd, &desired)
 
 	if err := r.client.Patch(ctx, crd, client.MergeFrom(base)); err != nil {
+		reconcilerActionsTotal.WithLabelValues(actionError).Inc()
 		log.WithError(err).Error("Failed to patch instance toward desired configuration")
 		return ctrl.Result{}, err
 	}
 
+	reconcilerActionsTotal.WithLabelValues(actionChanged).Inc()
 	log.Info("Reconciled instance to desired configuration")
 	return ctrl.Result{RequeueAfter: r.resync}, nil
 }

--- a/pkg/reconciler/unleash.go
+++ b/pkg/reconciler/unleash.go
@@ -1,0 +1,153 @@
+// Package reconciler contains bifrost's controller-runtime reconcile loop that
+// continuously converges bifrost-managed Unleash instances to the configuration
+// they should have. Unlike the request/response API, which applies config only
+// on POST/PUT, the reconciler re-renders every managed instance on CR events and
+// on a periodic resync, so global-config changes propagate and manual drift is
+// corrected.
+package reconciler
+
+import (
+	"context"
+	"time"
+
+	"github.com/nais/bifrost/pkg/config"
+	"github.com/nais/bifrost/pkg/domain/unleash"
+	"github.com/nais/bifrost/pkg/infrastructure/kubernetes"
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const defaultResyncInterval = 10 * time.Minute
+
+// UnleashReconciler converges bifrost-managed Unleash CRs to their desired spec.
+type UnleashReconciler struct {
+	client client.Client
+	config *config.Config
+	logger *logrus.Logger
+	resync time.Duration
+}
+
+// NewUnleashReconciler creates a reconciler. A non-positive resync falls back to
+// the default interval.
+func NewUnleashReconciler(c client.Client, cfg *config.Config, logger *logrus.Logger, resync time.Duration) *UnleashReconciler {
+	if resync <= 0 {
+		resync = defaultResyncInterval
+	}
+	return &UnleashReconciler{client: c, config: cfg, logger: logger, resync: resync}
+}
+
+// Reconcile renders the desired spec from the instance's intent and patches the
+// live CR toward it, preserving metadata, finalizers, ownerReferences, and the
+// status written by unleasherator.
+func (r *UnleashReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.logger.WithField("instance", req.Name)
+
+	crd := &unleashv1.Unleash{}
+	if err := r.client.Get(ctx, req.NamespacedName, crd); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Only touch instances bifrost owns; never a hand-authored or foreign CR.
+	if !kubernetes.IsManagedByBifrost(crd) {
+		return ctrl.Result{}, nil
+	}
+
+	cfg, err := r.resolveIntent(crd)
+	if err != nil {
+		// Intent is unusable; do not thrash. Requeue on the slow resync so a
+		// later fix (or a corrected annotation) is picked up.
+		log.WithError(err).Error("Failed to resolve desired-state intent; skipping reconcile")
+		return ctrl.Result{RequeueAfter: r.resync}, nil
+	}
+
+	// Preserve the existing federation nonce so rendering is deterministic;
+	// otherwise BuildUnleashCRD would mint a fresh random nonce every reconcile
+	// and the spec would never converge.
+	if crd.Spec.Federation.SecretNonce != "" {
+		cfg.FederationNonce = crd.Spec.Federation.SecretNonce
+	}
+
+	desired := kubernetes.BuildUnleashCRD(r.config, cfg)
+
+	if r.inSync(crd, &desired) {
+		return ctrl.Result{RequeueAfter: r.resync}, nil
+	}
+
+	base := crd.DeepCopy()
+	crd.Spec = desired.Spec
+	// Carry forward the (possibly backfilled) managed-by label and desired-state
+	// annotation from the render without dropping any foreign metadata.
+	applyManagedMetadata(crd, &desired)
+
+	if err := r.client.Patch(ctx, crd, client.MergeFrom(base)); err != nil {
+		log.WithError(err).Error("Failed to patch instance toward desired configuration")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Reconciled instance to desired configuration")
+	return ctrl.Result{RequeueAfter: r.resync}, nil
+}
+
+// resolveIntent returns the per-instance config, preferring the authoritative
+// desired-state annotation and falling back to reverse-engineering the spec for
+// instances created before the annotation existed.
+func (r *UnleashReconciler) resolveIntent(crd *unleashv1.Unleash) (*unleash.Config, error) {
+	if raw := crd.GetAnnotations()[kubernetes.AnnotationDesiredState]; raw != "" {
+		return kubernetes.UnmarshalIntent(raw)
+	}
+	return kubernetes.LoadConfigFromCRD(crd).Build()
+}
+
+// inSync reports whether the live spec and managed metadata already match the
+// desired render, so a no-op reconcile issues no patch.
+func (r *UnleashReconciler) inSync(live, desired *unleashv1.Unleash) bool {
+	if !equality.Semantic.DeepEqual(live.Spec, desired.Spec) {
+		return false
+	}
+	if live.GetLabels()[kubernetes.LabelManagedBy] != kubernetes.ManagedByBifrost {
+		return false
+	}
+	return live.GetAnnotations()[kubernetes.AnnotationDesiredState] == desired.GetAnnotations()[kubernetes.AnnotationDesiredState]
+}
+
+// applyManagedMetadata copies bifrost's managed-by label and desired-state
+// annotation from the render onto the live object, leaving all other metadata
+// intact.
+func applyManagedMetadata(live, desired *unleashv1.Unleash) {
+	if live.Labels == nil {
+		live.Labels = map[string]string{}
+	}
+	live.Labels[kubernetes.LabelManagedBy] = kubernetes.ManagedByBifrost
+
+	if desired.GetAnnotations()[kubernetes.AnnotationDesiredState] != "" {
+		if live.Annotations == nil {
+			live.Annotations = map[string]string{}
+		}
+		live.Annotations[kubernetes.AnnotationDesiredState] = desired.Annotations[kubernetes.AnnotationDesiredState]
+	}
+}
+
+// SetupWithManager registers the reconciler, filtered to bifrost-managed
+// instances so foreign Unleash CRs never enter the work queue.
+func (r *UnleashReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	managed, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{kubernetes.LabelManagedBy: kubernetes.ManagedByBifrost},
+	})
+	if err != nil {
+		return err
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&unleashv1.Unleash{}, builder.WithPredicates(managed)).
+		Named("bifrost-unleash").
+		Complete(r)
+}

--- a/pkg/reconciler/unleash_test.go
+++ b/pkg/reconciler/unleash_test.go
@@ -1,0 +1,139 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nais/bifrost/pkg/config"
+	"github.com/nais/bifrost/pkg/domain/unleash"
+	"github.com/nais/bifrost/pkg/infrastructure/kubernetes"
+	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Unleash: config.UnleashConfig{
+			InstanceNamespace:           "bifrost-unleash",
+			InstanceServiceaccount:      "sa",
+			SQLInstanceID:               "sql",
+			SQLInstanceAddress:          "10.0.0.1",
+			InstanceWebIngressHost:      "web.example",
+			InstanceWebIngressClass:     "web-class",
+			InstanceAPIIngressHost:      "api.example",
+			InstanceAPIIngressClass:     "api-class",
+			InstanceWebOAuthJWTAudience: "aud",
+			TeamsApiURL:                 "https://teams.example",
+			TeamsApiSecretName:          "teams",
+			TeamsApiSecretTokenKey:      "token",
+		},
+	}
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := unleashv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func newReconciler(c client.Client) *UnleashReconciler {
+	logger := logrus.New()
+	logger.SetOutput(nopWriter{})
+	return NewUnleashReconciler(c, testConfig(), logger, time.Minute)
+}
+
+func requestFor(crd *unleashv1.Unleash) ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Namespace: crd.Namespace, Name: crd.Name}}
+}
+
+// renderManaged produces a bifrost-managed, annotated CRD (with a fixed nonce so
+// rendering is deterministic).
+func renderManaged(name string) unleashv1.Unleash {
+	cfg := &unleash.Config{Name: name, CustomVersion: "1.2.3", FederationNonce: "fixed-nonce", EnableFederation: true}
+	return kubernetes.BuildUnleashCRD(testConfig(), cfg)
+}
+
+func TestReconcile_ConvergesDrift(t *testing.T) {
+	desired := renderManaged("team-a")
+	drifted := desired.DeepCopy()
+	drifted.Spec.ApiIngress.Class = "DRIFTED"         // an operator/manual edit
+	drifted.Spec.WebIngress.Host = "hijacked.example" // another drift
+
+	c := newFakeClient(t, drifted)
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(context.Background(), requestFor(drifted)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &unleashv1.Unleash{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: drifted.Namespace, Name: "team-a"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.ApiIngress.Class != "api-class" {
+		t.Errorf("ApiIngress.Class = %q, want %q (drift not corrected)", got.Spec.ApiIngress.Class, "api-class")
+	}
+	if got.Spec.WebIngress.Host != desired.Spec.WebIngress.Host {
+		t.Errorf("WebIngress.Host = %q, want %q (drift not corrected)", got.Spec.WebIngress.Host, desired.Spec.WebIngress.Host)
+	}
+}
+
+func TestReconcile_IgnoresUnmanaged(t *testing.T) {
+	desired := renderManaged("team-b")
+	foreign := desired.DeepCopy()
+	delete(foreign.Labels, kubernetes.LabelManagedBy) // not bifrost-managed
+	foreign.Spec.ApiIngress.Class = "hand-authored"
+
+	c := newFakeClient(t, foreign)
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(context.Background(), requestFor(foreign)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := &unleashv1.Unleash{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: foreign.Namespace, Name: "team-b"}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.ApiIngress.Class != "hand-authored" {
+		t.Errorf("unmanaged instance was modified: class = %q", got.Spec.ApiIngress.Class)
+	}
+}
+
+func TestReconcile_NoOpWhenInSync(t *testing.T) {
+	desired := renderManaged("team-c")
+	obj := desired.DeepCopy()
+
+	c := newFakeClient(t, obj)
+	r := newReconciler(c)
+
+	before := &unleashv1.Unleash{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: obj.Namespace, Name: "team-c"}, before); err != nil {
+		t.Fatalf("get before: %v", err)
+	}
+
+	if _, err := r.Reconcile(context.Background(), requestFor(obj)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	after := &unleashv1.Unleash{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: obj.Namespace, Name: "team-c"}, after); err != nil {
+		t.Fatalf("get after: %v", err)
+	}
+	if before.ResourceVersion != after.ResourceVersion {
+		t.Errorf("in-sync reconcile issued a write (RV %s -> %s)", before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/pkg/reconciler/unleash_test.go
+++ b/pkg/reconciler/unleash_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nais/bifrost/pkg/domain/unleash"
 	"github.com/nais/bifrost/pkg/infrastructure/kubernetes"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,7 +49,7 @@ func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
 func newReconciler(c client.Client) *UnleashReconciler {
 	logger := logrus.New()
 	logger.SetOutput(nopWriter{})
-	return NewUnleashReconciler(c, testConfig(), logger, time.Minute)
+	return NewUnleashReconciler(c, testConfig(), logger, time.Minute, false)
 }
 
 func requestFor(crd *unleashv1.Unleash) ctrl.Request {
@@ -131,6 +132,41 @@ func TestReconcile_NoOpWhenInSync(t *testing.T) {
 	}
 	if before.ResourceVersion != after.ResourceVersion {
 		t.Errorf("in-sync reconcile issued a write (RV %s -> %s)", before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+func TestReconcile_DryRunObservesWithoutWriting(t *testing.T) {
+	desired := renderManaged("team-d")
+	drifted := desired.DeepCopy()
+	drifted.Spec.ApiIngress.Class = "DRIFTED"
+
+	c := newFakeClient(t, drifted)
+	logger := logrus.New()
+	logger.SetOutput(nopWriter{})
+	r := NewUnleashReconciler(c, testConfig(), logger, time.Minute, true) // dry-run
+
+	before := &unleashv1.Unleash{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: drifted.Namespace, Name: "team-d"}, before); err != nil {
+		t.Fatalf("get before: %v", err)
+	}
+	wouldChangeBefore := testutil.ToFloat64(reconcilerActionsTotal.WithLabelValues(actionWouldChange))
+
+	if _, err := r.Reconcile(context.Background(), requestFor(drifted)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	after := &unleashv1.Unleash{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: drifted.Namespace, Name: "team-d"}, after); err != nil {
+		t.Fatalf("get after: %v", err)
+	}
+	if before.ResourceVersion != after.ResourceVersion {
+		t.Errorf("dry-run must not write (RV %s -> %s)", before.ResourceVersion, after.ResourceVersion)
+	}
+	if after.Spec.ApiIngress.Class != "DRIFTED" {
+		t.Errorf("dry-run changed the object: class = %q", after.Spec.ApiIngress.Class)
+	}
+	if got := testutil.ToFloat64(reconcilerActionsTotal.WithLabelValues(actionWouldChange)); got != wouldChangeBefore+1 {
+		t.Errorf("would_change counter = %v, want %v", got, wouldChangeBefore+1)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nais/bifrost/pkg/domain/releasechannel"
 	"github.com/nais/bifrost/pkg/infrastructure/cloudsql"
 	"github.com/nais/bifrost/pkg/infrastructure/kubernetes"
+	"github.com/nais/bifrost/pkg/reconciler"
 	fqdnV1alpha3 "github.com/nais/fqdn-policy/api/v1alpha3"
 	unleashv1 "github.com/nais/unleasherator/api/v1"
 	"github.com/sirupsen/logrus"
@@ -270,6 +271,24 @@ func Run(config *config.Config) {
 		logger.Info("Channel migration reconciler started in background")
 	}
 
+	// Start the controller-runtime reconcile loop if enabled. It continuously
+	// converges bifrost-managed Unleash instances to their desired config.
+	var reconcilerCancel context.CancelFunc
+	if config.Reconciler.Enabled {
+		mgr, err := reconciler.NewManager(config, logger)
+		if err != nil {
+			logger.Fatal(err)
+		}
+		var reconcilerCtx context.Context
+		reconcilerCtx, reconcilerCancel = context.WithCancel(context.Background())
+		go func() {
+			logger.Info("Starting Unleash reconciler manager")
+			if err := mgr.Start(reconcilerCtx); err != nil {
+				logger.WithError(err).Error("Unleash reconciler manager stopped with error")
+			}
+		}()
+	}
+
 	// Setup signal handler to gracefully shutdown migration reconcilers
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
@@ -298,6 +317,10 @@ func Run(config *config.Config) {
 	if channelMigrationCancel != nil {
 		logger.Info("Shutting down channel migration reconciler")
 		channelMigrationCancel()
+	}
+	if reconcilerCancel != nil {
+		logger.Info("Shutting down Unleash reconciler manager")
+		reconcilerCancel()
 	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
## Summary

First slice of the bifrost reconciler (#546, epic #543). Bifrost applies config
only on POST/PUT today, so global-config changes and manual edits drift forever.
This adds a controller-runtime reconcile loop that continuously converges
**bifrost-managed** Unleash instances to the configuration they should have.

**Feature-flagged off** (`BIFROST_RECONCILER_ENABLED`, default `false`) — merging
and deploying changes nothing until it's switched on per environment.

## What's in this slice

- **Managed-instance model.** `BuildUnleashCRD` now stamps every rendered
  instance with `app.kubernetes.io/managed-by: bifrost` and records the intent
  (the `unleash.Config`) as JSON in a `bifrost.nais.io/desired-state` annotation.
  The annotation is the authoritative, non-lossy source the reconciler
  re-renders from (avoiding the lossy `LoadConfigFromCRD` round-trip).
- **The reconcile loop.** `UnleashReconciler` watches managed instances
  (label-filtered so foreign/hand-authored CRs are never touched) plus a periodic
  resync, re-renders the desired spec, and converges via a `MergeFrom` patch that
  **preserves metadata, finalizers, ownerReferences, and unleasherator's status**
  (fixes the whole-object-clobber problem of the imperative `Update`). The
  existing federation nonce is preserved so rendering is deterministic and does
  not churn. Legacy instances without the annotation backfill it via
  `LoadConfigFromCRD`.
- **Manager.** Hosts the reconciler with the metrics server disabled (avoids
  colliding with the API port) and opt-in leader election. Wired into `Run()`
  with graceful shutdown.

## Configuration (all default-safe)

| Env var | Default | Purpose |
| --- | --- | --- |
| `BIFROST_RECONCILER_ENABLED` | `false` | Turn the loop on. |
| `BIFROST_RECONCILER_RESYNC_INTERVAL` | `10m` | Re-render cadence for drift correction. |
| `BIFROST_RECONCILER_LEADER_ELECTION` | `false` | Enable when running >1 replica (needs lease RBAC). |
| `BIFROST_RECONCILER_LEADER_ELECTION_NAMESPACE` | _(auto)_ | Lease namespace. |

## Testing

- `go build`, `go vet` clean; full suite (125 tests) passes.
- Fake-client reconcile tests: drift correction (ingress class/host reverted to
  desired), unmanaged-instance skipping, and steady-state no-op (no write when
  already in sync).

## Deliberately NOT in this slice (follow-ups on #546 / epic #543)

- **Database/secret convergence** — the reconciler currently converges the CR
  spec + managed metadata; ensuring the Cloud SQL database/user/secret from the
  loop (with owner references + a finalizer for external teardown) is next.
- **Server-side apply with an explicit field manager** — this slice uses a
  full-spec `MergeFrom` patch (matching today's `Update` semantics). Moving to
  SSA with a dedicated field manager, so bifrost owns only the fields it renders
  and provably never fights unleasherator, is a follow-up.
- **Making the API thin** (write intent + `202`, no inline side effects), the
  chart RBAC/lease wiring for leader election, and envtest coverage.
- `Size` is rendered as `1` (as today's `Update` already does); making replica
  count part of the intent is a later enhancement.

## Rollout

Enable in a non-prod tenant first (flag on, single replica), watch that managed
instances converge and steady-state issues no writes, then enable in prod.

Refs #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
