### PR TITLE
Harden GitHub tags client and use crypto/rand for random values

### DIFF
--- a/pkg/infrastructure/github/tags.go
+++ b/pkg/infrastructure/github/tags.go
@@ -1,11 +1,16 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"regexp"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -15,10 +20,35 @@ var (
 	unleashRepoName  = "unleash"
 )
 
-func getLatestTags(owner, repo string) ([]string, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/tags", githubApiUrl, owner, repo)
+const (
+	// githubRequestTimeout bounds a single tags request so a slow/hung GitHub
+	// connection cannot block the caller (and its request handler) indefinitely.
+	githubRequestTimeout = 10 * time.Second
+	// githubMaxResponseBytes caps how much of the response we read, guarding
+	// against an unexpectedly large body.
+	githubMaxResponseBytes = 5 << 20 // 5 MiB
+	// versionsCacheTTL is how long fetched versions are cached, so we do not hit
+	// GitHub (and its 60 req/hr unauthenticated rate limit) on every call.
+	versionsCacheTTL = 5 * time.Minute
+)
 
-	resp, err := http.Get(url)
+var httpClient = &http.Client{Timeout: githubRequestTimeout}
+
+func getLatestTags(ctx context.Context, owner, repo string) ([]string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/tags?per_page=100", githubApiUrl, owner, repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// Authenticate when a token is available to raise the rate limit from 60 to
+	// 5000 requests/hour, which matters behind shared cluster egress NAT.
+	if token := os.Getenv("BIFROST_GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -31,12 +61,11 @@ func getLatestTags(owner, repo string) ([]string, error) {
 	var tags []struct {
 		Name string `json:"name"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&tags)
-	if err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, githubMaxResponseBytes)).Decode(&tags); err != nil {
 		return nil, err
 	}
 
-	var tagNames []string
+	tagNames := make([]string, 0, len(tags))
 	for _, tag := range tags {
 		tagNames = append(tagNames, tag.Name)
 	}
@@ -81,20 +110,46 @@ type UnleashVersion struct {
 	GitTag        string
 }
 
+var (
+	versionsCacheMu   sync.Mutex
+	versionsCache     []UnleashVersion
+	versionsCacheTime time.Time
+)
+
+// UnleashVersions returns the known Unleash image versions, newest first.
+// Results are cached for versionsCacheTTL to avoid hammering the GitHub API.
 func UnleashVersions() ([]UnleashVersion, error) {
-	tags, err := getLatestTags(unleashRepoOwner, unleashRepoName)
+	versionsCacheMu.Lock()
+	defer versionsCacheMu.Unlock()
+
+	if versionsCache != nil && time.Since(versionsCacheTime) < versionsCacheTTL {
+		return versionsCache, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), githubRequestTimeout)
+	defer cancel()
+
+	tags, err := getLatestTags(ctx, unleashRepoOwner, unleashRepoName)
 	if err != nil {
 		return nil, err
 	}
 
-	versions := []UnleashVersion{}
-
+	versions := make([]UnleashVersion, 0, len(tags))
 	for _, tag := range tags {
 		version, err := tagToUnleashVersion(tag)
 		if err == nil {
 			versions = append(versions, version)
 		}
 	}
+
+	// Sort newest first by release time so callers that take index 0 get the
+	// latest release, independent of GitHub's tag ordering.
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].ReleaseTime.After(versions[j].ReleaseTime)
+	})
+
+	versionsCache = versions
+	versionsCacheTime = time.Now()
 
 	return versions, nil
 }

--- a/pkg/infrastructure/github/tags_test.go
+++ b/pkg/infrastructure/github/tags_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -54,6 +55,11 @@ func TestUnleashVersions(t *testing.T) {
 
 	githubApiUrl = server.URL
 
+	// Reset the cache so this test always fetches from its own test server.
+	versionsCacheMu.Lock()
+	versionsCache = nil
+	versionsCacheMu.Unlock()
+
 	versions, err := UnleashVersions()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, versions)
@@ -62,6 +68,13 @@ func TestUnleashVersions(t *testing.T) {
 		assert.NotEmpty(t, version.VersionNumber)
 		assert.NotEqual(t, version.ReleaseTime, time.Time{})
 		assert.NotEmpty(t, version.CommitHash)
+	}
+
+	// Versions must be sorted newest-first, so callers taking index 0 get the
+	// latest release regardless of GitHub's tag ordering.
+	for i := 1; i < len(versions); i++ {
+		assert.False(t, versions[i-1].ReleaseTime.Before(versions[i].ReleaseTime),
+			"versions not sorted newest-first: %s before %s", versions[i-1].GitTag, versions[i].GitTag)
 	}
 }
 
@@ -177,7 +190,7 @@ func TestGetLatestTags(t *testing.T) {
 
 			githubApiUrl = server.URL
 
-			got, err := getLatestTags(tc.owner, tc.repo)
+			got, err := getLatestTags(context.Background(), tc.owner, tc.repo)
 
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	"fmt"
+	"math/big"
 	"strings"
 )
 
@@ -28,6 +30,9 @@ func JoinNoEmpty(s []string, sep string) string {
 	return strings.Join(s, sep)
 }
 
+// RandomString returns a cryptographically-random string of length n over
+// [a-z0-9]. It is used for security-relevant values such as the federation
+// secret nonce, so it must not use a predictable (math/rand) source.
 func RandomString(n int) string {
 	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
 
@@ -38,6 +43,16 @@ func RandomString(n int) string {
 	return string(b)
 }
 
+// RandomInt returns a cryptographically-random int in [min, max) using unbiased
+// rejection sampling via crypto/rand. It panics only if the system CSPRNG is
+// unavailable, which is not a recoverable condition for a security primitive.
 func RandomInt(min, max int) int {
-	return min + rand.Intn(max-min)
+	if max <= min {
+		return min
+	}
+	r, err := crand.Int(crand.Reader, big.NewInt(int64(max-min)))
+	if err != nil {
+		panic(fmt.Sprintf("crypto/rand failure: %v", err))
+	}
+	return min + int(r.Int64())
 }


### PR DESCRIPTION
Two independent, conflict-free hardening fixes from the bifrost adversarial review, safe to review in parallel with #549/#550 (touches only `infrastructure/github/tags.go` and `utils/strings.go`).

## GitHub tags client (refs #548)
- **Timeout + request context** — a slow/hung GitHub connection no longer blocks the caller (and its request handler) indefinitely.
- **Optional auth** via `BIFROST_GITHUB_TOKEN` — raises the rate limit from 60 → 5000 req/hr behind shared cluster egress NAT (unauthenticated 403s were breaking version listing/provisioning).
- **Body size limit** (`io.LimitReader`, 5 MiB).
- **5-minute cache** — stops hammering GitHub on every call.
- **Newest-first sorting** by release time — callers taking index 0 (e.g. `SetDefaultVersionIfNeeded`) now get the latest release instead of an arbitrary tag from GitHub's ordering. This was silently pinning new instances to stale images.

## Random values (refs #544)
- `utils.RandomString`/`RandomInt` reimplemented on **crypto/rand** (unbiased). `RandomString` backs the federation secret nonce, which must not come from a predictable `math/rand` source. (DB passwords already use crypto/rand — this makes the nonce consistent.)

## Testing
- `go build`, `go vet`, `gofumpt` clean; full suite passes.
- Tests updated for the new `getLatestTags` signature; added a newest-first ordering assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)